### PR TITLE
Add zabbix-triggers as metric

### DIFF
--- a/zabbix/datasource.js
+++ b/zabbix/datasource.js
@@ -104,7 +104,7 @@ function (angular, _, dateMath) {
         if (target.mode !== 1) {
           // Don't show undefined and hidden targets
           if (target.hide || !target.group || !target.host
-            || !target.trigger) {
+            || !target.trigger.name ) {
             return [];
           }
 
@@ -117,7 +117,8 @@ function (angular, _, dateMath) {
           // "{host1,host2,...,hostN}" --> [host1, host2, ..., hostN]
           var groups = zabbixHelperSrv.splitMetrics(groupname);
           var hosts = zabbixHelperSrv.splitMetrics(hostname);
-          var triggers = zabbixHelperSrv.splitMetrics(triggername);
+          //var triggers = zabbixHelperSrv.splitMetrics(triggername);
+          var triggers = [triggername];
           
           console.log(groups, hosts, triggers);
 
@@ -144,15 +145,24 @@ function (angular, _, dateMath) {
                 
                 return self.zabbixAPI.performZabbixAPIRequest('event.get', params).then(function(events) {
                     console.log(events);
-                    return {
-                        target: target.trigger.name,
-                        datapoints: _.map(events, function(e) {
-                            //var value = "NOK";
-                            //if (e.value == 0) { value = "OK" }
-                            //return [target.trigger.name + ": " +e.value, e.clock * 1000];
-                            return [e.value, e.clock * 1000];
-                        })
-                    };
+                    if (events == []) {
+                        // Assuming trigger is OK if no events found
+                        // TODO: Get last trigger state from triggers list
+                        return {
+                            target: target.trigger.name,
+                            datapoints: [[0, to]]
+                        }
+                    } else {
+                        return {
+                            target: target.trigger.name,
+                            datapoints: _.map(events, function(e) {
+                                //var value = "NOK";
+                                //if (e.value == 0) { value = "OK" }
+                                //return [target.trigger.name + ": " +e.value, e.clock * 1000];
+                                return [e.value, e.clock * 1000];
+                            })
+                        };
+                    }
                 });
 
             });

--- a/zabbix/helperFunctions.js
+++ b/zabbix/helperFunctions.js
@@ -169,6 +169,17 @@ function (angular, _) {
       }
       return name;
     };
+    
+    /**
+     * Expand trigger name
+     *
+     * @param trigger: zabbix api trigger object
+     * @return {string} expanded trigger name (string)
+     */
+    this.expandTriggerName = function(trigger) {
+      var name = trigger.description;
+      return name;
+    };
 
     /**
      * Convert multiple mettrics to array

--- a/zabbix/partials/query.editor.html
+++ b/zabbix/partials/query.editor.html
@@ -116,30 +116,15 @@
         <i class="icon-warning-sign"></i>
       </a>
     </li>
-    <!-- Host filter -->
-    <li class="tight-form-item" ng-hide="target.mode == 2">
-      Filter
-      <i class="fa fa-question-circle"
-         bs-tooltip="'Filtering hosts by regex. Select All in items and specify regex for host names.'"></i>
-    </li>
-    <li ng-hide="target.mode == 2">
-      <input type="text"
-             class="tight-form-input input-large"
-             ng-model="target.hostFilter"
-             spellcheck='false'
-             placeholder="Host filter (regex)"
-             ng-blur="targetBlur()">
-    </li>
-    <!-- Downsampling function -->
-    <li class="tight-form-item input-medium" ng-hide="target.mode == 2">
-      Downsampling
-    </li>
-    <li ng-hide="target.mode == 2">
-      <select class="tight-form-input input-small"
-              ng-change="targetBlur()"
-              ng-model="target.downsampleFunction"
-              bs-tooltip="'Downsampling function'"
-              ng-options="func.name for func in downsampleFunctionList track by func.name">
+    <!-- Select Trigger -->
+    <li class="tight-form-item input-small" style="width: 3em">Trigger</li>
+    <li>
+      <select class="tight-form-input input-large"
+              ng-change="selectTrigger()"
+              ng-model="target.trigger"
+              bs-tooltip="target.trigger.name.length > 25 ? target.trigger.name : ''"
+              ng-options="trigger.name for trigger in metric.triggerList track by trigger.name">
+        <option value="">-- Select trigger --</option>
       </select>
       <a bs-tooltip="target.errors.metric"
          style="color: rgb(229, 189, 28)"
@@ -147,81 +132,10 @@
         <i class="icon-warning-sign"></i>
       </a>
     </li>
+
   </ul>
 
   <div class="clearfix"></div>
-</div>
 
-<div class="tight-form" ng-hide="target.mode == 1">
-  <ul class="tight-form-list" role="menu">
-    <li class="tight-form-item" style="min-width: 15px; text-align: center">&nbsp</li>
-    <li class="tight-form-item">
-      <i class="fa fa-eye invisible"></i>
-    </li>
-    <li class="tight-form-item" style="width: 135px">&nbsp</li>
-
-    <!-- Select Application -->
-    <li class="tight-form-item input-small" style="width: 5em">Application</li>
-    <li>
-      <select class="tight-form-input input-large"
-              ng-change="selectApplication()"
-              ng-model="target.application"
-              bs-tooltip="target.application.name.length > 15 ? target.application.name : ''"
-              ng-options="app.visible_name ? app.visible_name : app.name for app in metric.applicationList track by app.name">
-        <option value="">-- Select application --</option>
-      </select>
-      <a bs-tooltip="target.errors.metric"
-         style="color: rgb(229, 189, 28)"
-         ng-show="target.errors.metric">
-        <i class="icon-warning-sign"></i>
-      </a>
-    </li>
-    <!-- Select Item -->
-    <li class="tight-form-item input-small" style="width: 3em">Item</li>
-    <li>
-      <select class="tight-form-input input-large"
-              ng-change="selectItem()"
-              ng-model="target.item"
-              bs-tooltip="target.item.name.length > 25 ? target.item.name : ''"
-              ng-options="item.name for item in metric.itemList track by item.name">
-        <option value="">-- Select item --</option>
-      </select>
-      <a bs-tooltip="target.errors.metric"
-         style="color: rgb(229, 189, 28)"
-         ng-show="target.errors.metric">
-        <i class="icon-warning-sign"></i>
-      </a>
-    </li>
-    <!-- Item filter -->
-    <li class="tight-form-item" ng-hide="target.mode == 2">
-      Filter
-      <i class="fa fa-question-circle"
-         bs-tooltip="'Filtering items by regex. Select All in items and specify regex for item names.'"></i>
-    </li>
-    <li ng-hide="target.mode == 2">
-      <input type="text"
-             class="tight-form-input input-large"
-             ng-model="target.itemFilter"
-             spellcheck='false'
-             placeholder="Item filter (regex)"
-             ng-blur="targetBlur()">
-    </li>
-    <!-- Scale -->
-    <li class="tight-form-item" ng-hide="target.mode == 2">
-      Scale
-      <i class="fa fa-question-circle"
-         bs-tooltip="'Set a custom multiplier for series values, for example -1 to invert series'"></i>
-    </li>
-    <li ng-hide="target.mode == 2">
-      <input type="text"
-             class="tight-form-input input-small"
-             ng-model="target.scale"
-             spellcheck='false'
-             placeholder="1"
-             ng-blur="targetBlur()">
-    </li>
-  </ul>
-
-  <div class="clearfix"></div>
 </div>
 

--- a/zabbix/queryCtrl.js
+++ b/zabbix/queryCtrl.js
@@ -103,6 +103,7 @@ define([
         $scope.updateHostList();
         $scope.updateAppList();
         $scope.updateItemList();
+        $scope.updateTriggerList();
 
         $scope.target.errors = validateTarget($scope.target);
         if (!_.isEqual($scope.oldTarget, $scope.target) && _.isEmpty($scope.target.errors)) {
@@ -117,6 +118,7 @@ define([
       $scope.selectHost = function () {
         $scope.updateAppList();
         $scope.updateItemList();
+        $scope.updateTriggerList();
 
         $scope.target.errors = validateTarget($scope.target);
         if (!_.isEqual($scope.oldTarget, $scope.target) && _.isEmpty($scope.target.errors)) {
@@ -138,6 +140,17 @@ define([
         }
       };
 
+      /**
+       * Call when trigger selected
+       */
+      $scope.selectTrigger = function () {
+        $scope.target.errors = validateTarget($scope.target);
+        if (!_.isEqual($scope.oldTarget, $scope.target) && _.isEmpty($scope.target.errors)) {
+          $scope.oldTarget = angular.copy($scope.target);
+          $scope.get_data();
+        }
+      };      
+      
       /**
        * Call when item selected
        */
@@ -239,6 +252,31 @@ define([
           });
         }
       };
+      
+      /**
+       * Update list of trigger
+       */
+      $scope.updateTriggerList = function () {
+        var groups = $scope.target.group ? zabbixHelperSrv.splitMetrics(templateSrv.replace($scope.target.group.name)) : undefined;
+        var hosts = $scope.target.host ? zabbixHelperSrv.splitMetrics(templateSrv.replace($scope.target.host.name)) : undefined;
+        
+        console.log(groups, hosts);
+        
+        if (groups && hosts) {
+          $scope.datasource.zabbixAPI.triggerFindQuery(groups, hosts).then(function (triggers) {
+            // Show only unique trigger description
+            var uniq_triggers = _.map(_.uniq(triggers, function (trigger) {
+              return zabbixHelperSrv.expandTriggerName(trigger);
+            }), function (trigger) {
+              return {name: zabbixHelperSrv.expandTriggerName(trigger)};
+            });
+            $scope.metric.triggerList = [{name: 'All trigger'}];
+            addTemplatedVariables($scope.metric.triggerList);
+            $scope.metric.triggerList = $scope.metric.triggerList.concat(uniq_triggers);
+          });
+        }
+      };
+      
 
       /**
        * Add templated variables to list of available metrics

--- a/zabbix/zabbixAPIWrapper.js
+++ b/zabbix/zabbixAPIWrapper.js
@@ -297,6 +297,7 @@ function (angular, _) {
       var params = {
         output: ['name'],
         sortfield: 'description',
+        //expandDescription: true,
         //active: true
       };
       if (hostids) {
@@ -441,7 +442,6 @@ function (angular, _) {
       } else {
           return [];
       }
-
     };
 
     /**


### PR DESCRIPTION
This is my try on how to add zabbix triggers "as metric".
## Goal and achievement

My main goal is to generate a dashboard of trigger status, green if ok, red if not ok. I think with grafana and thanks to this plugin, we can really have the best of the two world !! It will save me a great amount of time, since we are currently making this kind of dashboard with various scripting ...

Here is a screenshot of what we can do with this fork:
![image](https://cloud.githubusercontent.com/assets/549513/13608579/bd80b184-e555-11e5-9c63-6cad35689f72.png)

What do you think about it ?
## Fork status

I'm not familiar with Angular at all ... here is what I didn't succeed to do:
- I beleive there should be another datasource type "Zabbix trigger". However I cannot get it to work, so I modified directly the existing datasource ... Therefore before merging it should eventually create another directory "zabbix-trigger" ?

Minors:
- It looks like the selected trigger is not saved
- I would like to get the trigger description "expanded", ie. no {HOSTNAME} anymore. But then it's hard to get the appropriate events.
- I didn't try with several trigger in the same graph
- I've seen too late there is on-going developement on another branch ...
