### PR TITLE
enable expanding MACRO in trigger descriptions

### DIFF
--- a/src/datasource-zabbix/zabbixAPI.service.js
+++ b/src/datasource-zabbix/zabbixAPI.service.js
@@ -327,6 +327,7 @@ function ZabbixAPIService($q, alertSrv, zabbixAPICoreService) {
         applicationids: applicationids,
         expandDescription: true,
         expandData: true,
+        expandComment: true,
         monitored: true,
         skipDependent: true,
         //only_true: true,


### PR DESCRIPTION
MACROs in trigger descriptions of the trigger panel are not expanded currently, this path to enable that