### PR TITLE
use gray font to distinguish acknowledged triggers

### DIFF
--- a/src/panel-triggers/module.html
+++ b/src/panel-triggers/module.html
@@ -46,7 +46,7 @@
               {{trigger.severity}}
             </div>
           </td>
-          <td style="background-color: {{trigger.color}}; color: white">
+          <td style="background-color: {{trigger.color}}; color: {{trigger.acknowledges.length ? 'darkgray' : 'white'}}">
             <div>
               {{trigger.description}}
               <a  ng-if="trigger.comments"


### PR DESCRIPTION
when both acknowledged and un-acknowledged triggers are displayed, it is not very clear to see the difference. 
this patch gray out the acknowledged ones to enable end users ignore them easily.