### PR TITLE
Fix items is undefined

### DIFF
--- a/src/datasource-zabbix/zabbixAPI.service.js
+++ b/src/datasource-zabbix/zabbixAPI.service.js
@@ -189,6 +189,9 @@ function ZabbixAPIServiceFactory(alertSrv, zabbixAPICoreService) {
       .then(expandItems);
 
       function expandItems(items) {
+        
+        if (typeof items === 'undefined') return [];
+        
         _.forEach(items, item => {
           item.item = item.name;
           item.name = utils.expandItemName(item.item, item.key_);


### PR DESCRIPTION
I see javascript error:

```
Potentially unhandled rejection [37] TypeError: Cannot read property 'forEach' of undefined
    at expandItems (http://localhost:3000/public/plugins/alexanderzobnin-zabbix-app/datasource-zabbix/zabbixAPI.service.js?bust=1490733977710:172:18)
    at i (http://localhost:3000/public/app/boot.5ee7468a.js:42:21962)
    at http://localhost:3000/public/app/boot.5ee7468a.js:42:22384
    at o.$eval (http://localhost:3000/public/app/boot.5ee7468a.js:42:29539)
    at o.$digest (http://localhost:3000/public/app/boot.5ee7468a.js:42:28012)
    at o.$apply (http://localhost:3000/public/app/boot.5ee7468a.js:42:29822)
    at http://localhost:3000/public/app/boot.5ee7468a.js:42:25872
    at f (http://localhost:3000/public/app/boot.5ee7468a.js:41:8103)
    at http://localhost:3000/public/app/boot.5ee7468a.js:41:9564
```

This should fix it.