### PR TITLE
Fix "data points outside time range" when there is no datapoints and aggregate function is used

### DIFF
--- a/src/datasource-zabbix/timeseries.js
+++ b/src/datasource-zabbix/timeseries.js
@@ -103,27 +103,31 @@ function groupBy_perf(datapoints, interval, groupByCallback) {
   let point_frame_ts = frame_ts;
   let point;
 
-  for (let i=0; i < datapoints.length; i++) {
-    point = datapoints[i];
-    point_frame_ts = getPointTimeFrame(point[POINT_TIMESTAMP], ms_interval);
-    if (point_frame_ts === frame_ts) {
-      frame_values.push(point[POINT_VALUE]);
-    } else if (point_frame_ts > frame_ts) {
-      frame_value = groupByCallback(frame_values);
-      grouped_series.push([frame_value, frame_ts]);
+  if (datapoints.length > 0) {
 
-      // Move frame window to next non-empty interval and fill empty by null
-      frame_ts += ms_interval;
-      while (frame_ts < point_frame_ts) {
-        grouped_series.push([null, frame_ts]);
+    for (let i=0; i < datapoints.length; i++) {
+      point = datapoints[i];
+      point_frame_ts = getPointTimeFrame(point[POINT_TIMESTAMP], ms_interval);
+      if (point_frame_ts === frame_ts) {
+        frame_values.push(point[POINT_VALUE]);
+      } else if (point_frame_ts > frame_ts) {
+        frame_value = groupByCallback(frame_values);
+        grouped_series.push([frame_value, frame_ts]);
+
+        // Move frame window to next non-empty interval and fill empty by null
         frame_ts += ms_interval;
+        while (frame_ts < point_frame_ts) {
+          grouped_series.push([null, frame_ts]);
+          frame_ts += ms_interval;
+        }
+        frame_values = [point[POINT_VALUE]];
       }
-      frame_values = [point[POINT_VALUE]];
     }
-  }
 
-  frame_value = groupByCallback(frame_values);
-  grouped_series.push([frame_value, frame_ts]);
+    frame_value = groupByCallback(frame_values);
+    grouped_series.push([frame_value, frame_ts]);
+
+  }
 
   return grouped_series;
 }


### PR DESCRIPTION
Patch to fix misleading "data points outside time range" alert message on a graph using aggregate function (say median(10m)) if metric has no data in a selected time range.
groupBy_perf function in datasource-zabbix/timeseries.js do not properly handle empty datapoints[] case inserting bogus [undefined, 0] sample with last grouped_series.push([frame_value, frame_ts]) call.
![image](https://user-images.githubusercontent.com/2250049/28211356-dd99939a-68a4-11e7-8946-cba1e287bc36.png)
![image](https://user-images.githubusercontent.com/2250049/28211401-1f56562e-68a5-11e7-8d31-ded745611909.png)
