### PR TITLE
Request extended output for applications from service

### DIFF
--- a/src/datasource-zabbix/zabbixAPI.service.js
+++ b/src/datasource-zabbix/zabbixAPI.service.js
@@ -139,7 +139,7 @@ function ZabbixAPIServiceFactory(alertSrv, zabbixAPICoreService) {
 
     getApps(hostids) {
       var params = {
-        output: ['applicationid', 'name'],
+        output: 'extend',
         hostids: hostids
       };
 


### PR DESCRIPTION
Solves issue #352
However, I've only tested it on Zabbix 2.0.6.
According to it's docs `output: 'extend'` should not break anything for other versions, but I might be wrong. 