### PR TITLE
Add placeholder for suggest-url

### DIFF
--- a/src/datasource-zabbix/partials/config.html
+++ b/src/datasource-zabbix/partials/config.html
@@ -1,4 +1,4 @@
-<datasource-http-settings current="ctrl.current">
+<datasource-http-settings current="ctrl.current" suggest-url="http://localhost/zabbix/api_jsonrpc.php">
 </datasource-http-settings>
 
 <div class="gf-form-group">
@@ -31,6 +31,7 @@
     label="Trends"
     checked="ctrl.current.jsonData.trends"
     switch-class="max-width-5">
+    
   </gf-form-switch>
   <div class="gf-form-inline">
     <div class="gf-form" ng-if="ctrl.current.jsonData.trends">

--- a/src/datasource-zabbix/partials/config.html
+++ b/src/datasource-zabbix/partials/config.html
@@ -32,7 +32,6 @@
     checked="ctrl.current.jsonData.trends"
     switch-class="max-width-5">
   </gf-form-switch>
-
   <div class="gf-form-inline">
     <div class="gf-form" ng-if="ctrl.current.jsonData.trends">
       <span class="gf-form-label width-7">

--- a/src/datasource-zabbix/partials/config.html
+++ b/src/datasource-zabbix/partials/config.html
@@ -31,8 +31,8 @@
     label="Trends"
     checked="ctrl.current.jsonData.trends"
     switch-class="max-width-5">
-    
   </gf-form-switch>
+
   <div class="gf-form-inline">
     <div class="gf-form" ng-if="ctrl.current.jsonData.trends">
       <span class="gf-form-label width-7">


### PR DESCRIPTION
Because it was empty.
Moreover, it requires not usual url, but url to Zabbix Api file (api_jsonrpc.php), so It it will be easier to connect with this placeholder.

Before:
![before](https://user-images.githubusercontent.com/1700286/40283054-189acdc6-5c81-11e8-93bf-7dedde17e1ef.jpg)

After:
![after](https://user-images.githubusercontent.com/1700286/40283057-1a9dbb06-5c81-11e8-8785-ca5e402984be.jpg)
