### PR TITLE
consolidateBy(sum) must calculate sums inside the one-hour trend period

### DIFF
--- a/src/datasource-zabbix/zabbix/connectors/sql/sqlConnector.js
+++ b/src/datasource-zabbix/zabbix/connectors/sql/sqlConnector.js
@@ -33,7 +33,8 @@ const consolidateByFunc = {
 const consolidateByTrendColumns = {
   'avg': 'value_avg',
   'min': 'value_min',
-  'max': 'value_max'
+  'max': 'value_max',
+  'sum': 'num*value_avg' // sum of sums inside the one-hour trend period
 };
 
 export class SQLConnector extends DBConnector {
@@ -98,7 +99,7 @@ export class SQLConnector extends DBConnector {
     let promises = _.map(grouped_items, (items, value_type) => {
       let itemids = _.map(items, 'itemid').join(', ');
       let table = TREND_TO_TABLE_MAP[value_type];
-      let valueColumn = _.includes(['avg', 'min', 'max'], consolidateBy) ? consolidateBy : 'avg';
+      let valueColumn = _.includes(['avg', 'min', 'max', 'sum'], consolidateBy) ? consolidateBy : 'avg';
       valueColumn = consolidateByTrendColumns[valueColumn];
       let query = this.sqlDialect.trendsQuery(itemids, table, timeFrom, timeTill, intervalSec, aggFunction, valueColumn);
 


### PR DESCRIPTION
This fixes https://github.com/alexanderzobnin/grafana-zabbix/issues/603.

After the fix, the produced SQL query looks like the following:
```
SELECT itemid AS metric, clock DIV 7200 * 7200 AS time_sec, SUM(num*value_avg) AS value FROM trends_uint WHERE itemid IN (282744, 282835) AND clock > 1531999580 AND clock < 1532604380 GROUP BY clock DIV 7200 * 7200, metric ORDER BY time_sec ASC
```

The calculated sum is correct since it sums the actual data values and not the one-hour trend period averages.