### PR TITLE
Support InfluxDB as a history db

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,7 +10,7 @@ coverage:
     patch: off
     changes: off
 
-comment: false
+comment: off
 
 ignore:
   - "dist/test/test-setup/.*"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,10 +6,9 @@ coverage:
   status:
     project:
       default:
-        target: 30%
-        threshold: 5%
-    patch: no
-    changes: no
+        threshold: 5
+    patch: off
+    changes: off
 
 comment: false
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -26,7 +26,7 @@ nav:
       - 'Upgrade': 'installation/upgrade.md'
   - Configuration:
       - 'Configuration': 'configuration/index.md'
-      - 'SQL Data Source Configuration': 'configuration/sql_datasource.md'
+      - 'Direct DB Connection Configuration': 'configuration/direct_db_datasource.md'
       - 'Provisioning': 'configuration/provisioning.md'
       - 'Troubleshooting': 'configuration/troubleshooting.md'
   - User Guides:

--- a/docs/sources/configuration/direct_db_datasource.md
+++ b/docs/sources/configuration/direct_db_datasource.md
@@ -32,3 +32,10 @@ database name (usually, `zabbix`) and specify credentials.
 ### Security notes
 
 Make sure you use read-only user for Zabbix database.
+
+## InfluxDB
+
+Select _InfluxDB_ data source type and provide your InfluxDB instance host address and port (8086 is default). Fill
+database name you configured in the [effluence](https://github.com/i-ky/effluence) module config (usually, `zabbix`) and specify credentials.
+
+![Configure InfluxDB data source](../img/configuration-influxdb_ds_config.png)

--- a/docs/sources/configuration/index.md
+++ b/docs/sources/configuration/index.md
@@ -62,6 +62,7 @@ Read [how to configure](./sql_datasource) SQL data source in Grafana.
 
 - **Enable**: enable Direct DB Connection.
 - **Data Source**: Select Data Source for Zabbix history database.
+- **Retention Policy** (InfluxDB only): Specify retention policy name for fetching long-term stored data. Grafana will fetch data from this retention policy if query time range suitable for trends query. Leave it blank if only default retention policy used.
 
 #### Supported databases
 

--- a/docs/sources/configuration/index.md
+++ b/docs/sources/configuration/index.md
@@ -61,11 +61,11 @@ amount of data transfered.
 Read [how to configure](./sql_datasource) SQL data source in Grafana.
 
 - **Enable**: enable Direct DB Connection.
-- **SQL Data Source**: Select SQL Data Source for Zabbix database.
+- **Data Source**: Select Data Source for Zabbix history database.
 
 #### Supported databases
 
-**MySQL** and **PostgreSQL** are supported by Grafana.
+**MySQL**, **PostgreSQL**, **InfluxDB** are supported as sources of historical data for the plugin.
 
 ### Alerting
 

--- a/docs/sources/configuration/provisioning.md
+++ b/docs/sources/configuration/provisioning.md
@@ -34,8 +34,11 @@ datasources:
     disableReadOnlyUsersAck: true
     # Direct DB Connection options
     dbConnectionEnable: true
-    # Name of existing SQL datasource
+    # Name of existing datasource for Direct DB Connection
     dbConnectionDatasourceName: MySQL Zabbix
+    # Retention policy name (InfluxDB only) for fetching long-term stored data.
+    # Leave it blank if only default retention policy used.
+    dbConnectionRetentionPolicy: one_year
   version: 1
   editable: false
 

--- a/docs/sources/img/configuration-influxdb_ds_config.png
+++ b/docs/sources/img/configuration-influxdb_ds_config.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:216a5d1a495fbd2093446c67e09a5dc669c65f541e65fcc13802facd411b5434
+size 111917

--- a/docs/sources/reference/direct-db-connection.md
+++ b/docs/sources/reference/direct-db-connection.md
@@ -81,7 +81,13 @@ As you can see, the Grafana-Zabbix plugin uses aggregation by a given time inter
 ## InfluxDB
 Zabbix supports loadable modules which makes possible to write history data into an external database. There's a [module](https://github.com/i-ky/effluence) for InfluxDB written by [@i-ky](https://github.com/i-ky) which can export history into InfluxDB in real-time.
 
-InfluxDB Query Example:
+#### InfluxDB retention policy
+In order to keep database size under control, you should use InfluxDB retention policy mechanism. It's possible to create retention policy for long-term data and write aggregated data in the same manner as Zabbix does (trends). Then this retention policy can be used in plugin for getting data after a certain period ([Retention Policy](../../configuration/#direct-db-connection) option in data source config). Read more about how to configure retention policy for using with plugin in effluence module [docs](https://github.com/i-ky/effluence#database-sizing).
+
+#### InfluxDB Query
+
+Eventually, plugin generates InfluxDB query similar to this:
+
 ```sql
 SELECT MEAN("value")
 FROM "history"

--- a/docs/sources/reference/direct-db-connection.md
+++ b/docs/sources/reference/direct-db-connection.md
@@ -1,6 +1,6 @@
 # Direct DB Connection
 
-Since version 4.3 Grafana can use MySQL as a native data source. The Grafana-Zabbix plugin can use this data source for querying data directly from a Zabbix database.
+Since version 4.3 Grafana can use MySQL as a native data source. The idea of Direct DB Connection is that Grafana-Zabbix plugin can use this data source for querying data directly from a Zabbix database.
 
 One of the most resource intensive queries for Zabbix API is the history query. For long time intervals `history.get`
 returns a huge amount of data. In order to display it, the plugin should adjust time series resolution
@@ -9,6 +9,8 @@ time series, but that data should be loaded and processed on the client side fir
 
 Also, many users see better performance from direct database queries versus API calls. This could be the result of several reasons,
 such as the additional PHP layer and additional SQL queries (user permissions checks).
+
+Direct DB Connection feature allows using database transparently for querying historical data. Now Grafana-Zabbix plugin supports few databases for history queries: MySQL, PostgreSQL and InfluxDB. Regardless of the database type, idea and data flow remain the same.
 
 ## Data Flow
 
@@ -75,6 +77,18 @@ ORDER BY time ASC
 **Note**: these queries may be changed in future, so look into sources for actual query structure.
 
 As you can see, the Grafana-Zabbix plugin uses aggregation by a given time interval. This interval is provided by Grafana and depends on the panel width in pixels. Thus, Grafana displays the data in the proper resolution.
+
+## InfluxDB
+Zabbix supports loadable modules which makes possible to write history data into an external database. There's a [module](https://github.com/i-ky/effluence) for InfluxDB written by [@i-ky](https://github.com/i-ky) which can export history into InfluxDB in real-time.
+
+InfluxDB Query Example:
+```sql
+SELECT MEAN("value")
+FROM "history"
+WHERE ("itemid" = '10073' OR "itemid" = '10074')
+  AND "time" >= 1540000000000s AND "time" <= 1540000000060s
+GROUP BY time(10s), "itemid" fill(none)
+```
 
 ## Functions usage with Direct DB Connection
 

--- a/src/datasource-zabbix/config.controller.js
+++ b/src/datasource-zabbix/config.controller.js
@@ -31,6 +31,7 @@ export class ZabbixDSConfigController {
     this.dbDataSources = this.getSupportedDBDataSources();
     this.zabbixVersions = _.cloneDeep(zabbixVersions);
     this.autoDetectZabbixVersion();
+    console.log(this.dbDataSources);
   }
 
   getSupportedDBDataSources() {
@@ -38,6 +39,12 @@ export class ZabbixDSConfigController {
     return _.filter(datasources, ds => {
       return _.includes(SUPPORTED_SQL_DS, ds.type);
     });
+  }
+
+  getCurrentDatasourceType() {
+    const dsId = this.current.jsonData.dbConnectionDatasourceId;
+    const currentDs = _.find(this.dbDataSources, { 'id': dsId });
+    return currentDs ? currentDs.type : null;
   }
 
   autoDetectZabbixVersion() {

--- a/src/datasource-zabbix/config.controller.js
+++ b/src/datasource-zabbix/config.controller.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import { migrateDSConfig } from './migrations';
 
 const SUPPORTED_SQL_DS = ['mysql', 'postgres', 'influxdb'];
+
 const zabbixVersions = [
   { name: '2.x', value: 2 },
   { name: '3.x', value: 3 },
@@ -27,12 +28,12 @@ export class ZabbixDSConfigController {
 
     this.current.jsonData = migrateDSConfig(this.current.jsonData);
     _.defaults(this.current.jsonData, defaultConfig);
-    this.sqlDataSources = this.getSupportedSQLDataSources();
+    this.dbDataSources = this.getSupportedDBDataSources();
     this.zabbixVersions = _.cloneDeep(zabbixVersions);
     this.autoDetectZabbixVersion();
   }
 
-  getSupportedSQLDataSources() {
+  getSupportedDBDataSources() {
     let datasources = this.datasourceSrv.getAll();
     return _.filter(datasources, ds => {
       return _.includes(SUPPORTED_SQL_DS, ds.type);

--- a/src/datasource-zabbix/config.controller.js
+++ b/src/datasource-zabbix/config.controller.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { migrateDSConfig } from './migrations';
 
-const SUPPORTED_SQL_DS = ['mysql', 'postgres'];
+const SUPPORTED_SQL_DS = ['mysql', 'postgres', 'influxdb'];
 const zabbixVersions = [
   { name: '2.x', value: 2 },
   { name: '3.x', value: 3 },

--- a/src/datasource-zabbix/datasource.js
+++ b/src/datasource-zabbix/datasource.js
@@ -58,6 +58,7 @@ export class ZabbixDatasource {
     this.enableDirectDBConnection = jsonData.dbConnectionEnable || false;
     this.dbConnectionDatasourceId = jsonData.dbConnectionDatasourceId;
     this.dbConnectionDatasourceName = jsonData.dbConnectionDatasourceName;
+    this.dbConnectionRetentionPolicy = jsonData.dbConnectionRetentionPolicy;
 
     let zabbixOptions = {
       url: this.url,
@@ -69,7 +70,8 @@ export class ZabbixDatasource {
       cacheTTL: this.cacheTTL,
       enableDirectDBConnection: this.enableDirectDBConnection,
       dbConnectionDatasourceId: this.dbConnectionDatasourceId,
-      dbConnectionDatasourceName: this.dbConnectionDatasourceName
+      dbConnectionDatasourceName: this.dbConnectionDatasourceName,
+      dbConnectionRetentionPolicy: this.dbConnectionRetentionPolicy,
     };
 
     this.zabbix = new Zabbix(zabbixOptions, datasourceSrv, backendSrv);

--- a/src/datasource-zabbix/datasource.js
+++ b/src/datasource-zabbix/datasource.js
@@ -618,8 +618,8 @@ export class ZabbixDatasource {
     let useTrendsFrom = Math.ceil(dateMath.parse('now-' + this.trendsFrom) / 1000);
     let useTrendsRange = Math.ceil(utils.parseInterval(this.trendsRange) / 1000);
     let useTrends = this.trends && (
-      (timeFrom <= useTrendsFrom) ||
-      (timeTo - timeFrom >= useTrendsRange)
+      (timeFrom < useTrendsFrom) ||
+      (timeTo - timeFrom > useTrendsRange)
     );
     return useTrends;
   }

--- a/src/datasource-zabbix/datasource.js
+++ b/src/datasource-zabbix/datasource.js
@@ -69,7 +69,7 @@ export class ZabbixDatasource {
       dbConnectionDatasourceName: this.dbConnectionDatasourceName
     };
 
-    this.zabbix = new Zabbix(zabbixOptions, backendSrv, datasourceSrv);
+    this.zabbix = new Zabbix(zabbixOptions, datasourceSrv, backendSrv);
   }
 
   ////////////////////////

--- a/src/datasource-zabbix/partials/config.html
+++ b/src/datasource-zabbix/partials/config.html
@@ -115,7 +115,7 @@
         Retention Policy
         <info-popover mode="right-normal">
           Specify retention policy name for fetching long-term stored data (optional).
-          Leave it blank if only default retention policy is using.
+          Leave it blank if only default retention policy used.
         </info-popover>
       </span>
       <input class="gf-form-input max-width-16"

--- a/src/datasource-zabbix/partials/config.html
+++ b/src/datasource-zabbix/partials/config.html
@@ -92,22 +92,38 @@
   </gf-form-switch>
   <div ng-if="ctrl.current.jsonData.dbConnectionEnable">
     <div class="gf-form max-width-30">
-    <span class="gf-form-label width-12">
-      Data Source
-      <info-popover mode="right-normal">
-        Select Data Source for Zabbix history database.
-        In order to use this feature it should be <a href="/datasources/new" target="_blank">created</a> and
-        configured first. Zabbix plugin uses this data source for querying history data directly from the database.
-        This way usually faster than pulling data from Zabbix API, especially on the wide time ranges, and reduces
-        amount of data transfered.
-      </info-popover>
-    </span>
-    <div class="gf-form-select-wrapper max-width-16">
-      <select class="gf-form-input" ng-model="ctrl.current.jsonData.dbConnectionDatasourceId"
-        ng-options="ds.id as ds.name for ds in ctrl.dbDataSources">
-      </select>
+      <span class="gf-form-label width-12">
+        Data Source
+        <info-popover mode="right-normal">
+          Select Data Source for Zabbix history database.
+          In order to use this feature it should be <a href="/datasources/new" target="_blank">created</a> and
+          configured first. Zabbix plugin uses this data source for querying history data directly from the database.
+          This way usually faster than pulling data from Zabbix API, especially on the wide time ranges, and reduces
+          amount of data transfered.
+        </info-popover>
+      </span>
+      <div class="gf-form-select-wrapper max-width-16">
+        <select class="gf-form-input" ng-model="ctrl.current.jsonData.dbConnectionDatasourceId"
+          ng-options="ds.id as ds.name for ds in ctrl.dbDataSources">
+        </select>
+      </div>
     </div>
   </div>
+  <div ng-if="ctrl.getCurrentDatasourceType() === 'influxdb'">
+    <div class="gf-form max-width-30">
+      <span class="gf-form-label width-12">
+        Retention Policy
+        <info-popover mode="right-normal">
+          Specify retention policy name for fetching long-term stored data (optional).
+          Leave it blank if only default retention policy is using.
+        </info-popover>
+      </span>
+      <input class="gf-form-input max-width-16"
+        type="text"
+        ng-model='ctrl.current.jsonData.dbConnectionRetentionPolicy'
+        placeholder="Retention policy name">
+      </input>
+    </div>
   </div>
 </div>
 

--- a/src/datasource-zabbix/partials/config.html
+++ b/src/datasource-zabbix/partials/config.html
@@ -91,20 +91,20 @@
     checked="ctrl.current.jsonData.dbConnectionEnable">
   </gf-form-switch>
   <div ng-if="ctrl.current.jsonData.dbConnectionEnable">
-    <div class="gf-form max-width-20">
+    <div class="gf-form max-width-30">
     <span class="gf-form-label width-12">
-      SQL Data Source
+      Data Source
       <info-popover mode="right-normal">
-        Select SQL Data Source for Zabbix database.
-        In order to use this feature you should <a href="/datasources/new" target="_blank">create</a> and
-        configure it first. Zabbix plugin uses this data source for querying history data directly from database.
+        Select Data Source for Zabbix history database.
+        In order to use this feature it should be <a href="/datasources/new" target="_blank">created</a> and
+        configured first. Zabbix plugin uses this data source for querying history data directly from the database.
         This way usually faster than pulling data from Zabbix API, especially on the wide time ranges, and reduces
         amount of data transfered.
       </info-popover>
     </span>
     <div class="gf-form-select-wrapper max-width-16">
       <select class="gf-form-input" ng-model="ctrl.current.jsonData.dbConnectionDatasourceId"
-        ng-options="ds.id as ds.name for ds in ctrl.sqlDataSources">
+        ng-options="ds.id as ds.name for ds in ctrl.dbDataSources">
       </select>
     </div>
   </div>

--- a/src/datasource-zabbix/specs/datasource.spec.js
+++ b/src/datasource-zabbix/specs/datasource.spec.js
@@ -56,7 +56,7 @@ describe('ZabbixDatasource', () => {
     });
 
     it('should use trends if it enabled and time more than trendsFrom', (done) => {
-      let ranges = ['now-7d', 'now-168h', 'now-1M', 'now-1y'];
+      let ranges = ['now-8d', 'now-169h', 'now-1M', 'now-1y'];
 
       _.forEach(ranges, range => {
         ctx.options.range.from = range;
@@ -73,7 +73,7 @@ describe('ZabbixDatasource', () => {
     });
 
     it('shouldnt use trends if it enabled and time less than trendsFrom', (done) => {
-      let ranges = ['now-6d', 'now-167h', 'now-1h', 'now-30m', 'now-30s'];
+      let ranges = ['now-7d', 'now-168h', 'now-1h', 'now-30m', 'now-30s'];
 
       _.forEach(ranges, range => {
         ctx.options.range.from = range;

--- a/src/datasource-zabbix/specs/dbConnector.test.js
+++ b/src/datasource-zabbix/specs/dbConnector.test.js
@@ -1,9 +1,8 @@
 import mocks from '../../test-setup/mocks';
-import DBConnector from '../zabbix/connectors/dbConnector';
+import { DBConnector } from '../zabbix/connectors/dbConnector';
 
 describe('DBConnector', () => {
   let ctx = {};
-  const backendSrv = mocks.backendSrvMock;
   const datasourceSrv = mocks.datasourceSrvMock;
   datasourceSrv.loadDatasource.mockResolvedValue({ id: 42, name: 'foo', meta: {} });
   datasourceSrv.getAll.mockReturnValue([{ id: 42, name: 'foo' }]);
@@ -20,14 +19,14 @@ describe('DBConnector', () => {
       ctx.options = {
         datasourceName: 'bar'
       };
-      const dbConnector = new DBConnector(ctx.options, backendSrv, datasourceSrv);
+      const dbConnector = new DBConnector(ctx.options, datasourceSrv);
       dbConnector.loadDBDataSource();
       expect(datasourceSrv.getAll).not.toHaveBeenCalled();
       expect(datasourceSrv.loadDatasource).toHaveBeenCalledWith('bar');
     });
 
     it('should load datasource by id if name not present', () => {
-      const dbConnector = new DBConnector(ctx.options, backendSrv, datasourceSrv);
+      const dbConnector = new DBConnector(ctx.options, datasourceSrv);
       dbConnector.loadDBDataSource();
       expect(datasourceSrv.getAll).toHaveBeenCalled();
       expect(datasourceSrv.loadDatasource).toHaveBeenCalledWith('foo');
@@ -35,13 +34,13 @@ describe('DBConnector', () => {
 
     it('should throw error if no name and id specified', () => {
       ctx.options = {};
-      const dbConnector = new DBConnector(ctx.options, backendSrv, datasourceSrv);
+      const dbConnector = new DBConnector(ctx.options, datasourceSrv);
       return expect(dbConnector.loadDBDataSource()).rejects.toBe('SQL Data Source name should be specified');
     });
 
     it('should throw error if datasource with given id is not found', () => {
       ctx.options.datasourceId = 45;
-      const dbConnector = new DBConnector(ctx.options, backendSrv, datasourceSrv);
+      const dbConnector = new DBConnector(ctx.options, datasourceSrv);
       return expect(dbConnector.loadDBDataSource()).rejects.toBe('SQL Data Source with ID 45 not found');
     });
   });

--- a/src/datasource-zabbix/specs/dbConnector.test.js
+++ b/src/datasource-zabbix/specs/dbConnector.test.js
@@ -15,7 +15,7 @@ describe('DBConnector', () => {
       };
     });
 
-    it('should load datasource by name by default', () => {
+    it('should try to load datasource by name first', () => {
       ctx.options = {
         datasourceName: 'bar'
       };
@@ -35,13 +35,13 @@ describe('DBConnector', () => {
     it('should throw error if no name and id specified', () => {
       ctx.options = {};
       const dbConnector = new DBConnector(ctx.options, datasourceSrv);
-      return expect(dbConnector.loadDBDataSource()).rejects.toBe('SQL Data Source name should be specified');
+      return expect(dbConnector.loadDBDataSource()).rejects.toBe('Data Source name should be specified');
     });
 
     it('should throw error if datasource with given id is not found', () => {
       ctx.options.datasourceId = 45;
       const dbConnector = new DBConnector(ctx.options, datasourceSrv);
-      return expect(dbConnector.loadDBDataSource()).rejects.toBe('SQL Data Source with ID 45 not found');
+      return expect(dbConnector.loadDBDataSource()).rejects.toBe('Data Source with ID 45 not found');
     });
   });
 });

--- a/src/datasource-zabbix/specs/influxdbConnector.test.js
+++ b/src/datasource-zabbix/specs/influxdbConnector.test.js
@@ -1,0 +1,95 @@
+import { InfluxDBConnector } from '../zabbix/connectors/influxdb/influxdbConnector';
+import { compactQuery } from '../utils';
+
+describe('InfluxDBConnector', () => {
+  let ctx = {};
+
+  beforeEach(() => {
+    ctx.options = { datasourceName: 'InfluxDB DS' };
+    ctx.datasourceSrvMock = {
+      loadDatasource: jest.fn().mockResolvedValue(
+        { id: 42, name: 'InfluxDB DS', meta: {} }
+      ),
+    };
+    ctx.influxDBConnector = new InfluxDBConnector(ctx.options, ctx.datasourceSrvMock);
+    ctx.influxDBConnector.invokeInfluxDBQuery = jest.fn().mockResolvedValue([]);
+    ctx.defaultQueryParams = {
+      itemids: ['123', '234'],
+      timeFrom: 15000, timeTill: 15100, intervalSec: 5,
+      table: 'history', aggFunction: 'MAX'
+    };
+  });
+
+  describe('When building InfluxDB query', () => {
+    it('should build proper query', () => {
+      const { itemids, timeFrom, timeTill, intervalSec, table, aggFunction } = ctx.defaultQueryParams;
+      const query = ctx.influxDBConnector.buildHistoryQuery(itemids, table, timeFrom, timeTill, intervalSec, aggFunction);
+      const expected = compactQuery(`SELECT MAX("value")
+        FROM "history" WHERE ("itemid" = '123' OR "itemid" = '234') AND "time" >= 15000s AND "time" <= 15100s
+        GROUP BY time(5s), "itemid" fill(none)
+      `);
+      expect(query).toBe(expected);
+    });
+
+    it('should use MEAN instead of AVG', () => {
+      const { itemids, timeFrom, timeTill, intervalSec, table } = ctx.defaultQueryParams;
+      const aggFunction = 'AVG';
+      const query = ctx.influxDBConnector.buildHistoryQuery(itemids, table, timeFrom, timeTill, intervalSec, aggFunction);
+      const expected = compactQuery(`SELECT MEAN("value")
+        FROM "history" WHERE ("itemid" = '123' OR "itemid" = '234') AND "time" >= 15000s AND "time" <= 15100s
+        GROUP BY time(5s), "itemid" fill(none)
+      `);
+      expect(query).toBe(expected);
+    });
+  });
+
+  describe('When invoking InfluxDB query', () => {
+    it('should query proper table depending on item type', () => {
+      const { timeFrom, timeTill} = ctx.defaultQueryParams;
+      const options = { intervalMs: 5000 };
+      const items = [
+        { itemid: '123', value_type: 3 }
+      ];
+      const expectedQuery = compactQuery(`SELECT MEAN("value")
+        FROM "history_uint" WHERE ("itemid" = '123') AND "time" >= 15000s AND "time" <= 15100s
+        GROUP BY time(5s), "itemid" fill(none)
+      `);
+      ctx.influxDBConnector.getHistory(items, timeFrom, timeTill, options);
+      expect(ctx.influxDBConnector.invokeInfluxDBQuery).toHaveBeenCalledWith(expectedQuery);
+    });
+
+    it('should split query if different item types are used', () => {
+      const { timeFrom, timeTill} = ctx.defaultQueryParams;
+      const options = { intervalMs: 5000 };
+      const items = [
+        { itemid: '123', value_type: 0 },
+        { itemid: '234', value_type: 3 },
+      ];
+      const sharedQueryPart = `AND "time" >= 15000s AND "time" <= 15100s GROUP BY time(5s), "itemid" fill(none)`;
+      const expectedQueryFirst = compactQuery(`SELECT MEAN("value")
+        FROM "history" WHERE ("itemid" = '123') ${sharedQueryPart}
+      `);
+      const expectedQuerySecond = compactQuery(`SELECT MEAN("value")
+        FROM "history_uint" WHERE ("itemid" = '234') ${sharedQueryPart}
+      `);
+      ctx.influxDBConnector.getHistory(items, timeFrom, timeTill, options);
+      expect(ctx.influxDBConnector.invokeInfluxDBQuery).toHaveBeenCalledTimes(2);
+      expect(ctx.influxDBConnector.invokeInfluxDBQuery).toHaveBeenNthCalledWith(1, expectedQueryFirst);
+      expect(ctx.influxDBConnector.invokeInfluxDBQuery).toHaveBeenNthCalledWith(2, expectedQuerySecond);
+    });
+
+    it('should use the same table for trends query', () => {
+      const { timeFrom, timeTill} = ctx.defaultQueryParams;
+      const options = { intervalMs: 5000 };
+      const items = [
+        { itemid: '123', value_type: 3 }
+      ];
+      const expectedQuery = compactQuery(`SELECT MEAN("value")
+        FROM "history_uint" WHERE ("itemid" = '123') AND "time" >= 15000s AND "time" <= 15100s
+        GROUP BY time(5s), "itemid" fill(none)
+      `);
+      ctx.influxDBConnector.getTrends(items, timeFrom, timeTill, options);
+      expect(ctx.influxDBConnector.invokeInfluxDBQuery).toHaveBeenCalledWith(expectedQuery);
+    });
+  });
+});

--- a/src/datasource-zabbix/utils.js
+++ b/src/datasource-zabbix/utils.js
@@ -258,6 +258,13 @@ export function parseVersion(version) {
   return { major, minor, patch, meta };
 }
 
+/**
+ * Replaces any space-like symbols (tabs, new lines, spaces) by single whitespace.
+ */
+export function compactQuery(query) {
+  return query.replace(/\s+/g, ' ').trim();
+}
+
 // Fix for backward compatibility with lodash 2.4
 if (!_.includes) {
   _.includes = _.contains;

--- a/src/datasource-zabbix/zabbix/connectors/dbConnector.js
+++ b/src/datasource-zabbix/zabbix/connectors/dbConnector.js
@@ -1,12 +1,40 @@
 import _ from 'lodash';
 
+export const DEFAULT_QUERY_LIMIT = 10000;
+export const HISTORY_TO_TABLE_MAP = {
+  '0': 'history',
+  '1': 'history_str',
+  '2': 'history_log',
+  '3': 'history_uint',
+  '4': 'history_text'
+};
+
+export const TREND_TO_TABLE_MAP = {
+  '0': 'trends',
+  '3': 'trends_uint'
+};
+
+export const consolidateByFunc = {
+  'avg': 'AVG',
+  'min': 'MIN',
+  'max': 'MAX',
+  'sum': 'SUM',
+  'count': 'COUNT'
+};
+
+export const consolidateByTrendColumns = {
+  'avg': 'value_avg',
+  'min': 'value_min',
+  'max': 'value_max',
+  'sum': 'num*value_avg' // sum of sums inside the one-hour trend period
+};
+
 /**
  * Base class for external history database connectors. Subclasses should implement `getHistory()`, `getTrends()` and
  * `testDataSource()` methods, which describe how to fetch data from source other than Zabbix API.
  */
-export default class DBConnector {
-  constructor(options, backendSrv, datasourceSrv) {
-    this.backendSrv = backendSrv;
+export class DBConnector {
+  constructor(options, datasourceSrv) {
     this.datasourceSrv = datasourceSrv;
     this.datasourceId = options.datasourceId;
     this.datasourceName = options.datasourceName;
@@ -106,3 +134,14 @@ function convertGrafanaTSResponse(time_series, items, addHostName) {
 
   return _.sortBy(grafanaSeries, 'target');
 }
+
+const defaults = {
+  DBConnector,
+  DEFAULT_QUERY_LIMIT,
+  HISTORY_TO_TABLE_MAP,
+  TREND_TO_TABLE_MAP,
+  consolidateByFunc,
+  consolidateByTrendColumns
+};
+
+export default defaults;

--- a/src/datasource-zabbix/zabbix/connectors/dbConnector.js
+++ b/src/datasource-zabbix/zabbix/connectors/dbConnector.js
@@ -42,24 +42,31 @@ export class DBConnector {
     this.datasourceTypeName = null;
   }
 
-  loadDBDataSource() {
-    if (!this.datasourceName && this.datasourceId !== undefined) {
-      let ds = _.find(this.datasourceSrv.getAll(), {'id': this.datasourceId});
+  static loadDatasource(dsId, dsName, datasourceSrv) {
+    if (!dsName && dsId !== undefined) {
+      let ds = _.find(datasourceSrv.getAll(), {'id': dsId});
       if (!ds) {
-        return Promise.reject(`SQL Data Source with ID ${this.datasourceId} not found`);
+        return Promise.reject(`Data Source with ID ${dsId} not found`);
       }
-      this.datasourceName = ds.name;
+      dsName = ds.name;
     }
-    if (this.datasourceName) {
-      return this.datasourceSrv.loadDatasource(this.datasourceName)
-      .then(ds => {
-        this.datasourceTypeId = ds.meta.id;
-        this.datasourceTypeName = ds.meta.name;
-        return ds;
-      });
+    if (dsName) {
+      return datasourceSrv.loadDatasource(dsName);
     } else {
-      return Promise.reject(`SQL Data Source name should be specified`);
+      return Promise.reject(`Data Source name should be specified`);
     }
+  }
+
+  loadDBDataSource() {
+    return DBConnector.loadDatasource(this.datasourceId, this.datasourceName, this.datasourceSrv)
+    .then(ds => {
+      this.datasourceTypeId = ds.meta.id;
+      this.datasourceTypeName = ds.meta.name;
+      if (!this.datasourceName) {
+        this.datasourceName = ds.name;
+      }
+      return ds;
+    });
   }
 
   /**

--- a/src/datasource-zabbix/zabbix/connectors/influxdb/influxdbConnector.js
+++ b/src/datasource-zabbix/zabbix/connectors/influxdb/influxdbConnector.js
@@ -74,6 +74,12 @@ function handleInfluxHistoryResponse(results) {
   const seriesList = [];
   for (let i = 0; i < results.length; i++) {
     const result = results[i];
+
+    if (result.error) {
+      const error = `InfluxDB error: ${result.error}`;
+      return Promise.reject(new Error(error));
+    }
+
     if (!result || !result.series) {
       continue;
     }

--- a/src/datasource-zabbix/zabbix/connectors/influxdb/influxdbConnector.js
+++ b/src/datasource-zabbix/zabbix/connectors/influxdb/influxdbConnector.js
@@ -1,10 +1,9 @@
 import _ from 'lodash';
-import { DBConnector, DEFAULT_QUERY_LIMIT, HISTORY_TO_TABLE_MAP, consolidateByFunc } from '../dbConnector';
+import { DBConnector, HISTORY_TO_TABLE_MAP, consolidateByFunc } from '../dbConnector';
 
 export class InfluxDBConnector extends DBConnector {
   constructor(options, datasourceSrv) {
     super(options, datasourceSrv);
-    this.limit = options.limit || DEFAULT_QUERY_LIMIT;
     super.loadDBDataSource().then(ds => {
       this.influxDS = ds;
       return ds;

--- a/src/datasource-zabbix/zabbix/connectors/influxdb/influxdbConnector.js
+++ b/src/datasource-zabbix/zabbix/connectors/influxdb/influxdbConnector.js
@@ -1,0 +1,152 @@
+import _ from 'lodash';
+import DBConnector from '../dbConnector';
+
+const DEFAULT_QUERY_LIMIT = 10000;
+const HISTORY_TO_TABLE_MAP = {
+  '0': 'history',
+  '1': 'history_str',
+  '2': 'history_log',
+  '3': 'history_uint',
+  '4': 'history_text'
+};
+
+const TREND_TO_TABLE_MAP = {
+  '0': 'trends',
+  '3': 'trends_uint'
+};
+
+const consolidateByFunc = {
+  'avg': 'AVG',
+  'min': 'MIN',
+  'max': 'MAX',
+  'sum': 'SUM',
+  'count': 'COUNT'
+};
+
+const consolidateByTrendColumns = {
+  'avg': 'value_avg',
+  'min': 'value_min',
+  'max': 'value_max',
+  'sum': 'num*value_avg' // sum of sums inside the one-hour trend period
+};
+
+export class InfluxDBConnector extends DBConnector {
+  constructor(options, backendSrv, datasourceSrv) {
+    super(options, backendSrv, datasourceSrv);
+    this.limit = options.limit || DEFAULT_QUERY_LIMIT;
+    super.loadDBDataSource().then(ds => {
+      console.log(ds);
+      this.ds = ds;
+      return ds;
+    });
+  }
+
+  /**
+   * Try to invoke test query for one of Zabbix database tables.
+   */
+  testDataSource() {
+    return this.ds.testDatasource();
+  }
+
+  getHistory(items, timeFrom, timeTill, options) {
+    let {intervalMs, consolidateBy} = options;
+    const intervalSec = Math.ceil(intervalMs / 1000);
+
+    consolidateBy = consolidateBy || 'avg';
+    const aggFunction = consolidateByFunc[consolidateBy];
+
+    // Group items by value type and perform request for each value type
+    const grouped_items = _.groupBy(items, 'value_type');
+    const promises = _.map(grouped_items, (items, value_type) => {
+      const itemids = _.map(items, 'itemid');
+      const table = HISTORY_TO_TABLE_MAP[value_type];
+      const query = this.buildHistoryQuery(itemids, table, timeFrom, timeTill, intervalSec, aggFunction);
+      console.log(query);
+      return this.invokeInfluxDBQuery(query);
+    });
+
+    return Promise.all(promises).then(results => {
+      return _.flatten(results);
+    });
+  }
+
+  getTrends(items, timeFrom, timeTill, options) {
+    let { intervalMs, consolidateBy } = options;
+    const intervalSec = Math.ceil(intervalMs / 1000);
+
+    consolidateBy = consolidateBy || 'avg';
+    const aggFunction = consolidateByFunc[consolidateBy];
+
+    // Group items by value type and perform request for each value type
+    const grouped_items = _.groupBy(items, 'value_type');
+    const promises = _.map(grouped_items, (items, value_type) => {
+      const itemids = _.map(items, 'itemid');
+      const table = TREND_TO_TABLE_MAP[value_type];
+      let valueColumn = _.includes(['avg', 'min', 'max', 'sum'], consolidateBy) ? consolidateBy : 'avg';
+      valueColumn = consolidateByTrendColumns[valueColumn];
+      const query = this.buildTrendsQuery(itemids, table, timeFrom, timeTill, intervalSec, aggFunction, valueColumn);
+      console.log(query);
+      return this.invokeInfluxDBQuery(query);
+    });
+
+    return Promise.all(promises).then(results => {
+      return _.flatten(results);
+    });
+  }
+
+  buildHistoryQuery(itemids, table, timeFrom, timeTill, intervalSec, aggFunction) {
+    const AGG = aggFunction === 'AVG' ? 'MEAN' : aggFunction;
+    const where_clause = itemids.map(itemid => `"itemid" = ${itemid}`).join(' AND ');
+    const query = `SELECT "itemid", "time", ${AGG}("value") FROM "${table}"
+      WHERE ${where_clause} AND "time" >= ${timeFrom} AND "time" <= ${timeTill}
+      GROUP BY time(${intervalSec}s)`;
+    return compactQuery(query);
+  }
+
+  buildTrendsQuery(itemids, table, timeFrom, timeTill, intervalSec, aggFunction, valueColumn) {
+    const AGG = aggFunction === 'AVG' ? 'MEAN' : aggFunction;
+    const where_clause = itemids.map(itemid => `"itemid" = ${itemid}`).join(' AND ');
+    const query = `SELECT "itemid", "time", ${AGG}("${valueColumn}") FROM "${table}"
+      WHERE ${where_clause} AND "time" >= ${timeFrom} AND "time" <= ${timeTill}
+      GROUP BY time(${intervalSec}s)`;
+    return compactQuery(query);
+  }
+
+  handleGrafanaTSResponse(history, items, addHostName = true) {
+    return convertGrafanaTSResponse(history, items, addHostName);
+  }
+
+  invokeInfluxDBQuery(query) {
+    return this.ds._seriesQuery(query);
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+function convertGrafanaTSResponse(time_series, items, addHostName) {
+  //uniqBy is needed to deduplicate
+  var hosts = _.uniqBy(_.flatten(_.map(items, 'hosts')), 'hostid');
+  let grafanaSeries = _.map(_.compact(time_series), series => {
+    let itemid = series.name;
+    var item = _.find(items, {'itemid': itemid});
+    var alias = item.name;
+    //only when actual multi hosts selected
+    if (_.keys(hosts).length > 1 && addHostName) {
+      var host = _.find(hosts, {'hostid': item.hostid});
+      alias = host.name + ": " + alias;
+    }
+    // CachingProxy deduplicates requests and returns one time series for equal queries.
+    // Clone is needed to prevent changing of series object shared between all targets.
+    let datapoints = _.cloneDeep(series.points);
+    return {
+      target: alias,
+      datapoints: datapoints
+    };
+  });
+
+  return _.sortBy(grafanaSeries, 'target');
+}
+
+function compactQuery(query) {
+  return query.replace(/\s+/g, ' ');
+}

--- a/src/datasource-zabbix/zabbix/connectors/influxdb/influxdbConnector.js
+++ b/src/datasource-zabbix/zabbix/connectors/influxdb/influxdbConnector.js
@@ -23,7 +23,7 @@ export class InfluxDBConnector extends DBConnector {
     const intervalSec = Math.ceil(intervalMs / 1000);
 
     consolidateBy = consolidateBy || 'avg';
-    const aggFunction = consolidateByFunc[consolidateBy];
+    const aggFunction = consolidateByFunc[consolidateBy] || consolidateBy;
 
     // Group items by value type and perform request for each value type
     const grouped_items = _.groupBy(items, 'value_type');

--- a/src/datasource-zabbix/zabbix/connectors/influxdb/influxdbConnector.js
+++ b/src/datasource-zabbix/zabbix/connectors/influxdb/influxdbConnector.js
@@ -1,38 +1,9 @@
 import _ from 'lodash';
-import DBConnector from '../dbConnector';
-
-const DEFAULT_QUERY_LIMIT = 10000;
-const HISTORY_TO_TABLE_MAP = {
-  '0': 'history',
-  '1': 'history_str',
-  '2': 'history_log',
-  '3': 'history_uint',
-  '4': 'history_text'
-};
-
-const TREND_TO_TABLE_MAP = {
-  '0': 'trends',
-  '3': 'trends_uint'
-};
-
-const consolidateByFunc = {
-  'avg': 'AVG',
-  'min': 'MIN',
-  'max': 'MAX',
-  'sum': 'SUM',
-  'count': 'COUNT'
-};
-
-const consolidateByTrendColumns = {
-  'avg': 'value_avg',
-  'min': 'value_min',
-  'max': 'value_max',
-  'sum': 'num*value_avg' // sum of sums inside the one-hour trend period
-};
+import { DBConnector, DEFAULT_QUERY_LIMIT, HISTORY_TO_TABLE_MAP, consolidateByFunc } from '../dbConnector';
 
 export class InfluxDBConnector extends DBConnector {
-  constructor(options, backendSrv, datasourceSrv) {
-    super(options, backendSrv, datasourceSrv);
+  constructor(options, datasourceSrv) {
+    super(options, datasourceSrv);
     this.limit = options.limit || DEFAULT_QUERY_LIMIT;
     super.loadDBDataSource().then(ds => {
       this.influxDS = ds;
@@ -71,28 +42,7 @@ export class InfluxDBConnector extends DBConnector {
   }
 
   getTrends(items, timeFrom, timeTill, options) {
-    let { intervalMs, consolidateBy } = options;
-    const intervalSec = Math.ceil(intervalMs / 1000);
-
-    consolidateBy = consolidateBy || 'avg';
-    const aggFunction = consolidateByFunc[consolidateBy];
-
-    // Group items by value type and perform request for each value type
-    const grouped_items = _.groupBy(items, 'value_type');
-    const promises = _.map(grouped_items, (items, value_type) => {
-      const itemids = _.map(items, 'itemid');
-      const table = TREND_TO_TABLE_MAP[value_type];
-      let valueColumn = _.includes(['avg', 'min', 'max', 'sum'], consolidateBy) ? consolidateBy : 'avg';
-      valueColumn = consolidateByTrendColumns[valueColumn];
-      const query = this.buildTrendsQuery(itemids, table, timeFrom, timeTill, intervalSec, aggFunction, valueColumn);
-      return this.invokeInfluxDBQuery(query);
-    });
-
-    return Promise.all(promises)
-    .then(_.flatten)
-    .then(results => {
-      return handleInfluxHistoryResponse(results);
-    });
+    return this.getHistory(items, timeFrom, timeTill, options);
   }
 
   buildHistoryQuery(itemids, table, timeFrom, timeTill, intervalSec, aggFunction) {
@@ -101,15 +51,6 @@ export class InfluxDBConnector extends DBConnector {
     const query = `SELECT ${AGG}("value") FROM "${table}"
       WHERE ${where_clause} AND "time" >= ${timeFrom}s AND "time" <= ${timeTill}s
       GROUP BY time(${intervalSec}s), "itemid" fill(linear)`;
-    return compactQuery(query);
-  }
-
-  buildTrendsQuery(itemids, table, timeFrom, timeTill, intervalSec, aggFunction, valueColumn) {
-    const AGG = aggFunction === 'AVG' ? 'MEAN' : aggFunction;
-    const where_clause = this.buildWhereClause(itemids);
-    const query = `SELECT ${AGG}("${valueColumn}") FROM "${table}"
-      WHERE ${where_clause} AND "time" >= ${timeFrom}s AND "time" <= ${timeTill}s
-      GROUP BY time(${intervalSec}s)`;
     return compactQuery(query);
   }
 

--- a/src/datasource-zabbix/zabbix/connectors/influxdb/influxdbConnector.js
+++ b/src/datasource-zabbix/zabbix/connectors/influxdb/influxdbConnector.js
@@ -50,7 +50,7 @@ export class InfluxDBConnector extends DBConnector {
     const where_clause = this.buildWhereClause(itemids);
     const query = `SELECT ${AGG}("value") FROM "${table}"
       WHERE ${where_clause} AND "time" >= ${timeFrom}s AND "time" <= ${timeTill}s
-      GROUP BY time(${intervalSec}s), "itemid" fill(linear)`;
+      GROUP BY time(${intervalSec}s), "itemid" fill(none)`;
     return compactQuery(query);
   }
 

--- a/src/datasource-zabbix/zabbix/connectors/influxdb/influxdbConnector.js
+++ b/src/datasource-zabbix/zabbix/connectors/influxdb/influxdbConnector.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { compactQuery } from '../../../utils';
 import { DBConnector, HISTORY_TO_TABLE_MAP, consolidateByFunc } from '../dbConnector';
 
 export class InfluxDBConnector extends DBConnector {
@@ -103,8 +104,4 @@ function handleInfluxHistoryResponse(results) {
   }
 
   return seriesList;
-}
-
-function compactQuery(query) {
-  return query.replace(/\s+/g, ' ');
 }

--- a/src/datasource-zabbix/zabbix/connectors/sql/sqlConnector.js
+++ b/src/datasource-zabbix/zabbix/connectors/sql/sqlConnector.js
@@ -112,10 +112,6 @@ export class SQLConnector extends DBConnector {
     });
   }
 
-  handleGrafanaTSResponse(history, items, addHostName = true) {
-    return convertGrafanaTSResponse(history, items, addHostName);
-  }
-
   invokeSQLQuery(query) {
     let queryDef = {
       refId: 'A',
@@ -143,31 +139,6 @@ export class SQLConnector extends DBConnector {
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-
-function convertGrafanaTSResponse(time_series, items, addHostName) {
-  //uniqBy is needed to deduplicate
-  var hosts = _.uniqBy(_.flatten(_.map(items, 'hosts')), 'hostid');
-  let grafanaSeries = _.map(_.compact(time_series), series => {
-    let itemid = series.name;
-    var item = _.find(items, {'itemid': itemid});
-    var alias = item.name;
-    //only when actual multi hosts selected
-    if (_.keys(hosts).length > 1 && addHostName) {
-      var host = _.find(hosts, {'hostid': item.hostid});
-      alias = host.name + ": " + alias;
-    }
-    // CachingProxy deduplicates requests and returns one time series for equal queries.
-    // Clone is needed to prevent changing of series object shared between all targets.
-    let datapoints = _.cloneDeep(series.points);
-    return {
-      target: alias,
-      datapoints: datapoints
-    };
-  });
-
-  return _.sortBy(grafanaSeries, 'target');
-}
 
 function compactSQLQuery(query) {
   return query.replace(/\s+/g, ' ');

--- a/src/datasource-zabbix/zabbix/connectors/sql/sqlConnector.js
+++ b/src/datasource-zabbix/zabbix/connectors/sql/sqlConnector.js
@@ -113,7 +113,6 @@ export class SQLConnector extends DBConnector {
   }
 }
 
-
 function compactSQLQuery(query) {
   return query.replace(/\s+/g, ' ');
 }

--- a/src/datasource-zabbix/zabbix/connectors/sql/sqlConnector.js
+++ b/src/datasource-zabbix/zabbix/connectors/sql/sqlConnector.js
@@ -9,15 +9,17 @@ const supportedDatabases = {
 };
 
 export class SQLConnector extends DBConnector {
-  constructor(options, datasourceSrv, backendSrv) {
+  constructor(options, datasourceSrv) {
     super(options, datasourceSrv);
-    this.backendSrv = backendSrv;
 
     this.limit = options.limit || DEFAULT_QUERY_LIMIT;
     this.sqlDialect = null;
 
     super.loadDBDataSource()
-    .then(() => this.loadSQLDialect());
+    .then(ds => {
+      this.backendSrv = ds.backendSrv;
+      this.loadSQLDialect();
+    });
   }
 
   loadSQLDialect() {

--- a/src/datasource-zabbix/zabbix/connectors/sql/sqlConnector.js
+++ b/src/datasource-zabbix/zabbix/connectors/sql/sqlConnector.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { compactQuery } from '../../../utils';
 import mysql from './mysql';
 import postgres from './postgres';
 import dbConnector, { DBConnector, DEFAULT_QUERY_LIMIT, HISTORY_TO_TABLE_MAP, TREND_TO_TABLE_MAP } from '../dbConnector';
@@ -52,7 +53,7 @@ export class SQLConnector extends DBConnector {
       let table = HISTORY_TO_TABLE_MAP[value_type];
       let query = this.sqlDialect.historyQuery(itemids, table, timeFrom, timeTill, intervalSec, aggFunction);
 
-      query = compactSQLQuery(query);
+      query = compactQuery(query);
       return this.invokeSQLQuery(query);
     });
 
@@ -77,7 +78,7 @@ export class SQLConnector extends DBConnector {
       valueColumn = dbConnector.consolidateByTrendColumns[valueColumn];
       let query = this.sqlDialect.trendsQuery(itemids, table, timeFrom, timeTill, intervalSec, aggFunction, valueColumn);
 
-      query = compactSQLQuery(query);
+      query = compactQuery(query);
       return this.invokeSQLQuery(query);
     });
 
@@ -111,8 +112,4 @@ export class SQLConnector extends DBConnector {
       }
     });
   }
-}
-
-function compactSQLQuery(query) {
-  return query.replace(/\s+/g, ' ');
 }

--- a/src/datasource-zabbix/zabbix/zabbix.js
+++ b/src/datasource-zabbix/zabbix/zabbix.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import * as utils from '../utils';
 import responseHandler from '../responseHandler';
-import DBConnector from './connectors/dbConnector';
+import { DBConnector } from './connectors/dbConnector';
 import { ZabbixAPIConnector } from './connectors/zabbix_api/zabbixAPIConnector';
 import { SQLConnector } from './connectors/sql/sqlConnector';
 import { InfluxDBConnector } from './connectors/influxdb/influxdbConnector';
@@ -25,7 +25,7 @@ const REQUESTS_TO_BIND = [
 ];
 
 export class Zabbix {
-  constructor(options, backendSrv, datasourceSrv) {
+  constructor(options, datasourceSrv, backendSrv) {
     let {
       url,
       username,
@@ -59,12 +59,12 @@ export class Zabbix {
         datasourceId: dbConnectionDatasourceId,
         datasourceName: dbConnectionDatasourceName
       };
-      this.dbConnector = new DBConnector(dbConnectorOptions, backendSrv, datasourceSrv);
+      this.dbConnector = new DBConnector(dbConnectorOptions, datasourceSrv);
       this.dbConnector.loadDBDataSource().then(ds => {
         if (ds.type === 'influxdb') {
-          this.dbConnector = new InfluxDBConnector(dbConnectorOptions, backendSrv, datasourceSrv);
+          this.dbConnector = new InfluxDBConnector(dbConnectorOptions, datasourceSrv);
         } else {
-          this.dbConnector = new SQLConnector(dbConnectorOptions, backendSrv, datasourceSrv);
+          this.dbConnector = new SQLConnector(dbConnectorOptions, datasourceSrv, backendSrv);
         }
       }).then(() => {
         this.getHistoryDB = this.cachingProxy.proxyfyWithCache(this.dbConnector.getHistory, 'getHistory', this.dbConnector);

--- a/src/test-setup/jest-setup.js
+++ b/src/test-setup/jest-setup.js
@@ -54,6 +54,12 @@ jest.mock('grafana/app/core/table_model', () => {
   };
 }, {virtual: true});
 
+jest.mock('grafana/app/core/config', () => {
+  return {
+    buildInfo: { env: 'development' }
+  };
+}, {virtual: true});
+
 jest.mock('jquery', () => 'module not found', {virtual: true});
 
 // Required for loading angularjs


### PR DESCRIPTION
This PR closes #640 and adds support for InfluxDB as Direct DB Connection datasource along with MySQL and Postgres.
