### PR TITLE
Expand macros in trigger URL fields

### DIFF
--- a/src/datasource-zabbix/utils.js
+++ b/src/datasource-zabbix/utils.js
@@ -67,13 +67,26 @@ export function containsMacro(itemName) {
   return MACRO_PATTERN.test(itemName);
 }
 
-export function replaceMacro(item, macros) {
-  let itemName = item.name;
+export function replaceMacro(item, macros, isTriggerItem) {
+  let itemName = isTriggerItem ? item.url : item.name;
   let item_macros = itemName.match(MACRO_PATTERN);
   _.forEach(item_macros, macro => {
     let host_macros = _.filter(macros, m => {
       if (m.hostid) {
-        return m.hostid === item.hostid;
+        if (isTriggerItem) {
+          // Trigger item can have multiple hosts
+          // Check all trigger host ids against macro host id
+          let hostIdFound = false;
+          _.forEach(item.hosts, h => {
+            if (h.hostid === m.hostid) {
+              hostIdFound = true;
+            }
+          });
+          return hostIdFound;
+        } else {
+          // Check app host id against macro host id
+          return m.hostid === item.hostid;
+        }
       } else {
         // Add global macros
         return true;

--- a/src/datasource-zabbix/zabbix/zabbix.js
+++ b/src/datasource-zabbix/zabbix/zabbix.js
@@ -242,9 +242,9 @@ export class Zabbix {
       _.forEach(items, item => {
         if (utils.containsMacro(isTriggerItem ? item.url : item.name)) {
           if (isTriggerItem) {
-              item.url = utils.replaceMacro(item, macros, isTriggerItem);
+            item.url = utils.replaceMacro(item, macros, isTriggerItem);
           } else {
-              item.name = utils.replaceMacro(item, macros);
+            item.name = utils.replaceMacro(item, macros);
           }
         }
       });

--- a/src/datasource-zabbix/zabbix/zabbix.js
+++ b/src/datasource-zabbix/zabbix/zabbix.js
@@ -235,13 +235,17 @@ export class Zabbix {
     .then(this.expandUserMacro.bind(this));
   }
 
-  expandUserMacro(items) {
+  expandUserMacro(items, isTriggerItem) {
     let hostids = getHostIds(items);
     return this.getMacros(hostids)
     .then(macros => {
       _.forEach(items, item => {
-        if (utils.containsMacro(item.name)) {
-          item.name = utils.replaceMacro(item, macros);
+        if (utils.containsMacro(isTriggerItem ? item.url : item.name)) {
+          if (isTriggerItem) {
+              item.url = utils.replaceMacro(item, macros, isTriggerItem);
+          } else {
+              item.name = utils.replaceMacro(item, macros);
+          }
         }
       });
       return items;
@@ -286,7 +290,8 @@ export class Zabbix {
       return query;
     })
     .then(query => this.zabbixAPI.getTriggers(query.groupids, query.hostids, query.applicationids, options))
-    .then(triggers => this.filterTriggersByProxy(triggers, proxyFilter));
+    .then(triggers => this.filterTriggersByProxy(triggers, proxyFilter))
+    .then(triggers => this.expandUserMacro.bind(this)(triggers, true));
   }
 
   filterTriggersByProxy(triggers, proxyFilter) {


### PR DESCRIPTION
Fix to issue #190 

Currently macros in trigger URL field don't get expanded.
This fix checks trigger URL against macros and expands all found macros.