### PR TITLE
Problems panel: manual problem closing

### DIFF
--- a/src/datasource-zabbix/constants.js
+++ b/src/datasource-zabbix/constants.js
@@ -23,6 +23,7 @@ export const SHOW_OK_EVENTS = 1;
 
 // Acknowledge
 export const ZBX_ACK_ACTION_NONE = 0;
+export const ZBX_ACK_ACTION_CLOSE = 1;
 export const ZBX_ACK_ACTION_ACK = 2;
 export const ZBX_ACK_ACTION_ADD_MESSAGE = 4;
 

--- a/src/datasource-zabbix/zabbix/connectors/zabbix_api/zabbixAPIConnector.js
+++ b/src/datasource-zabbix/zabbix/connectors/zabbix_api/zabbixAPIConnector.js
@@ -91,8 +91,17 @@ export class ZabbixAPIConnector {
   // Zabbix API method wrappers //
   ////////////////////////////////
 
-  acknowledgeEvent(eventid, message) {
-    const action = this.version >= 4 ? ZBX_ACK_ACTION_ACK + ZBX_ACK_ACTION_ADD_MESSAGE : ZBX_ACK_ACTION_NONE;
+  acknowledgeEvent(eventid, message, closeProblem) {
+    var action = ZBX_ACK_ACTION_NONE;
+    if (this.version >= 4)
+    {
+      action = ZBX_ACK_ACTION_ACK + ZBX_ACK_ACTION_ADD_MESSAGE;
+      if (closeProblem == true)
+      {
+        action += ZBX_ACK_ACTION_CLOSE;
+      }
+    }
+    
     const params = {
       eventids: eventid,
       message: message,

--- a/src/panel-triggers/components/Modal.tsx
+++ b/src/panel-triggers/components/Modal.tsx
@@ -16,6 +16,7 @@ interface ModalState {
   value: string;
   error: boolean;
   message: string;
+  closeProblem: boolean;
 }
 
 export interface AckProblemData {
@@ -33,6 +34,7 @@ export class Modal extends PureComponent<ModalProps, ModalState> {
       value: '',
       error: false,
       message: '',
+      closeProblem: false,
     };
 
     this.modalContainer = document.body;
@@ -41,6 +43,11 @@ export class Modal extends PureComponent<ModalProps, ModalState> {
   handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     this.setState({ value: event.target.value, error: false });
   }
+  
+  handleChangeCheckbox = () => {
+    this.setState({ closeProblem: !this.state.closeProblem, });
+  }
+
 
   handleKeyUp = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.which === KEYBOARD_ENTER_KEY || event.key === 'Enter') {
@@ -67,7 +74,8 @@ export class Modal extends PureComponent<ModalProps, ModalState> {
       });
     }
     this.props.onSubmit({
-      message: this.state.value
+      message: this.state.value,
+      closeProblem: this.state.closeProblem
     }).then(() => {
       this.dismiss();
     });
@@ -116,6 +124,10 @@ export class Modal extends PureComponent<ModalProps, ModalState> {
 
             <div className="gf-form-button-row text-center">
               <button className="btn btn-success" onClick={this.submit}>Acknowledge</button>
+              <label className="btn btn-inverse" style={{ marginRight: 14 }}>
+                <input style={{ marginRight: 5 }} type="checkbox" onChange={this.handleChangeCheckbox}/>
+                Close problem
+              </label>
               <button className="btn btn-inverse" onClick={this.dismiss}>Cancel</button>
             </div>
           </div>

--- a/src/panel-triggers/triggers_panel_ctrl.js
+++ b/src/panel-triggers/triggers_panel_ctrl.js
@@ -602,7 +602,7 @@ export class TriggerPanelCtrl extends PanelCtrl {
     this.render();
   }
 
-  acknowledgeTrigger(trigger, message) {
+  acknowledgeTrigger(trigger, message, closeProblem) {
     let eventid = trigger.lastEvent ? trigger.lastEvent.eventid : null;
     let grafana_user = this.contextSrv.user.name;
     let ack_message = grafana_user + ' (Grafana): ' + message;
@@ -613,7 +613,7 @@ export class TriggerPanelCtrl extends PanelCtrl {
         return Promise.reject({message: 'You have no permissions to acknowledge events.'});
       }
       if (eventid) {
-        return datasource.zabbix.acknowledgeEvent(eventid, ack_message);
+        return datasource.zabbix.acknowledgeEvent(eventid, ack_message, closeProblem);
       } else {
         return Promise.reject({message: 'Trigger has no events. Nothing to acknowledge.'});
       }


### PR DESCRIPTION
suggestion for https://github.com/alexanderzobnin/grafana-zabbix/issues/524

* Currently it is only possible to acknowledge a problem in the Grafana Problems panel. Manually closing one isn't possible.
* I've added a checkbox in the Acknowledge menu so that the required action flag in the "event.acknowledge" api call is set. (read/write permission for the api user is necessary)

![closeProblem](https://user-images.githubusercontent.com/19889940/60175842-fe04b500-9814-11e9-916d-39e228a0a528.PNG)


I'm not really familiar with React/other stuff so some changes might be unnecessary/done poorly.
There's room for improvments. The CSS style tag in Modal.tsx is just for testing, didn't wan't to mess with CSS too much
* If possible it would be nice to hide the checkbox if manual closing isn't possible. Haven't found a way to access manualClose from ProblemStatusBar.tsx in Modal.tsx in order to do that