### PR TITLE
fix not acknowledged problem color with a message

### DIFF
--- a/src/panel-triggers/components/AlertList/AlertCard.tsx
+++ b/src/panel-triggers/components/AlertList/AlertCard.tsx
@@ -72,7 +72,7 @@ export default class AlertCard extends PureComponent<AlertCardProps, AlertCardSt
     let problemColor: string;
     if (problem.value === '0') {
       problemColor = panelOptions.okEventColor;
-    } else if (panelOptions.markAckEvents && problem.lastEvent.acknowledged == "1") {
+    } else if (panelOptions.markAckEvents && problem.lastEvent.acknowledged === "1") {
       problemColor = panelOptions.ackEventColor;
     } else {
       problemColor = severityDesc.color;

--- a/src/panel-triggers/components/AlertList/AlertCard.tsx
+++ b/src/panel-triggers/components/AlertList/AlertCard.tsx
@@ -72,7 +72,7 @@ export default class AlertCard extends PureComponent<AlertCardProps, AlertCardSt
     let problemColor: string;
     if (problem.value === '0') {
       problemColor = panelOptions.okEventColor;
-    } else if (panelOptions.markAckEvents && problem.acknowledges && problem.acknowledges.length) {
+    } else if (panelOptions.markAckEvents && problem.lastEvent.acknowledged == "1") {
       problemColor = panelOptions.ackEventColor;
     } else {
       problemColor = severityDesc.color;

--- a/src/panel-triggers/components/Problems/Problems.tsx
+++ b/src/panel-triggers/components/Problems/Problems.tsx
@@ -183,7 +183,7 @@ function SeverityCell(props: RTCell<ZBXTrigger>, problemSeverityDesc: TriggerSev
   color = severityDesc.color;
 
   // Mark acknowledged triggers with different color
-  if (markAckEvents && problem.acknowledges && problem.acknowledges.length) {
+  if (markAckEvents && problem.lastEvent.acknowledged == "1") {
     color = ackEventColor;
   }
 

--- a/src/panel-triggers/components/Problems/Problems.tsx
+++ b/src/panel-triggers/components/Problems/Problems.tsx
@@ -183,7 +183,7 @@ function SeverityCell(props: RTCell<ZBXTrigger>, problemSeverityDesc: TriggerSev
   color = severityDesc.color;
 
   // Mark acknowledged triggers with different color
-  if (markAckEvents && problem.lastEvent.acknowledged == "1") {
+  if (markAckEvents && problem.lastEvent.acknowledged === "1") {
     color = ackEventColor;
   }
 


### PR DESCRIPTION
This PR closes #857.

As described in the issue #857 if a problem contains a message without the acknowledgment, then the severity color is shown as acknowleged in both views: table and list.

Zabbix [event object](https://www.zabbix.com/documentation/current/manual/api/reference/event/get) has property "acknowledged" which is 1 if the event has been acknowledged. I've used this property instead of "acknowledges" object, because acknowledges will contain the message attached to the event even if the event is not acknowleged.
