### PR TITLE
Fix percentile() function, closes #862

### DIFF
--- a/src/datasource-zabbix/dataProcessor.js
+++ b/src/datasource-zabbix/dataProcessor.js
@@ -121,9 +121,11 @@ function aggregateWrapper(groupByCallback, interval, datapoints) {
 }
 
 function percentile(interval, n, datapoints) {
-  var flattenedPoints = ts.flattenDatapoints(datapoints);
-  var groupByCallback = _.partial(PERCENTILE, n);
-  return groupBy(flattenedPoints, interval, groupByCallback);
+  const flattenedPoints = ts.flattenDatapoints(datapoints);
+  // groupBy_perf works with sorted series only
+  const sortedPoints = ts.sortByTime(flattenedPoints);
+  let groupByCallback = _.partial(PERCENTILE, n);
+  return groupBy(sortedPoints, interval, groupByCallback);
 }
 
 function timeShift(interval, range) {


### PR DESCRIPTION
Like the other aggregation functions, the datapoints need to be sorted in
time before calling groupBy_perf().
Closes #862

