### PR TITLE
Added data source column for table layout

### DIFF
--- a/src/panel-triggers/components/AlertList/AlertCard.tsx
+++ b/src/panel-triggers/components/AlertList/AlertCard.tsx
@@ -56,7 +56,7 @@ export default class AlertCard extends PureComponent<AlertCardProps, AlertCardSt
 
   render() {
     const { problem, panelOptions } = this.props;
-    const showDatasourceName = panelOptions.targets && panelOptions.targets.length > 1;
+    const showDatasourceName = panelOptions.dataSourceField;
     const cardClass = classNames('alert-rule-item', 'zbx-trigger-card', { 'zbx-trigger-highlighted': panelOptions.highlightBackground });
     const descriptionClass = classNames('alert-rule-item__text', { 'zbx-description--newline': panelOptions.descriptionAtNewLine });
     const severityDesc = _.find(panelOptions.triggerSeverity, s => s.priority === Number(problem.priority));

--- a/src/panel-triggers/components/Problems/Problems.tsx
+++ b/src/panel-triggers/components/Problems/Problems.tsx
@@ -89,6 +89,7 @@ export default class ProblemList extends PureComponent<ProblemListProps, Problem
     const statusIconCell = props => StatusIconCell(props, highlightNewerThan);
 
     const columns = [
+      { Header: 'Data Source', accessor: 'datasource', show: options.dataSourceField },
       { Header: 'Host', accessor: 'host', show: options.hostField },
       { Header: 'Host (Technical Name)', accessor: 'hostTechName', show: options.hostTechNameField },
       { Header: 'Host Groups', accessor: 'groups', show: options.hostGroups, Cell: GroupCell },

--- a/src/panel-triggers/partials/options_tab.html
+++ b/src/panel-triggers/partials/options_tab.html
@@ -56,6 +56,12 @@
       checked="ctrl.panel.ageField"
       on-change="ctrl.render()">
     </gf-form-switch>
+    <gf-form-switch class="gf-form"
+      label-class="width-9"
+      label="Data Source"
+      checked="ctrl.panel.dataSourceField"
+      on-change="ctrl.render()">
+    </gf-form-switch>
     <gf-form-switch ng-if="ctrl.panel.layout === 'list'"
       class="gf-form"
       label-class="width-9"

--- a/src/panel-triggers/triggers_panel_ctrl.js
+++ b/src/panel-triggers/triggers_panel_ctrl.js
@@ -62,7 +62,7 @@ export const PANEL_DEFAULTS = {
   statusIcon: false,
   severityField: true,
   ageField: false,
-  dataSourceField: true,
+  dataSourceField: false,
   descriptionField: true,
   descriptionAtNewLine: false,
   // Options

--- a/src/panel-triggers/triggers_panel_ctrl.js
+++ b/src/panel-triggers/triggers_panel_ctrl.js
@@ -62,6 +62,7 @@ export const PANEL_DEFAULTS = {
   statusIcon: false,
   severityField: true,
   ageField: false,
+  dataSourceField: true,
   descriptionField: true,
   descriptionAtNewLine: false,
   // Options

--- a/src/panel-triggers/types.ts
+++ b/src/panel-triggers/types.ts
@@ -12,6 +12,7 @@ export interface ProblemsPanelOptions {
   statusIcon?: boolean;
   severityField?: boolean;
   ageField?: boolean;
+  dataSourceField?: boolean;
   descriptionField?: boolean;
   descriptionAtNewLine?: boolean;
   // Options


### PR DESCRIPTION
This PR is just a suggestion thas closes #700

- Added dataSourceField panel option
- Added column "Data Source" for table layout
- As list layout already shows "Data Source" field it would be logical to show/hide data source based on the same new option. Added that.
- So far the option is made "true" by default, because it always was in list. However after an update the column will be visible to everyone that uses table layout. Other way is to use that new option by default as false and only for table layout, thus it will not change anything after a plugin update.

