### PR TITLE
Fix ITEM.VALUE act like ITEM.LASTVALUE in annotations (#891)

### DIFF
--- a/src/datasource-zabbix/datasource.js
+++ b/src/datasource-zabbix/datasource.js
@@ -536,12 +536,13 @@ export class ZabbixDatasource {
             let title = Number(event.value) ? 'Problem' : 'OK';
 
             let formatted_acknowledges = utils.formatAcknowledges(event.acknowledges);
+            let event_name = this.zabbixVersion < 4 ? indexedTriggers[event.objectid].description : event.name;
             return {
               annotation: annotation,
               time: event.clock * 1000,
               title: title,
               tags: tags,
-              text: indexedTriggers[event.objectid].description + formatted_acknowledges
+              text: event_name + formatted_acknowledges
             };
           });
         });


### PR DESCRIPTION
Before Zabbix 4.0 the described behavior was unpleasant but expected.
From [docs for {ITEM.VALUE}](https://www.zabbix.com/documentation/3.0/manual/appendix/macros/supported_by_location):
> Resolved to either:
> 1) the historical (at-the-time-of-event) value of the Nth item in the trigger expression, if used in the context of trigger status change, for example, when displaying events or sending notifications.
> 2) the latest value of the Nth item in the trigger expression, if used without the context of trigger status change, for example, when displaying a list of triggers in a pop-up selection window. In this case works the same as {ITEM.LASTVALUE}

But this changes with Zabbix 4.0+. The macros resolution works the same, but [Event object](https://www.zabbix.com/documentation/4.0/manual/api/reference/event/object) now has a new property `name` that contains event name resolved in the correct way (using at-the-time-of-event value).