### PR TITLE
[Doc] change link in index.md

### DIFF
--- a/docs/sources/configuration/index.md
+++ b/docs/sources/configuration/index.md
@@ -58,7 +58,7 @@ Direct DB Connection allows plugin to use existing SQL data source for querying 
 database. This way usually faster than pulling data from Zabbix API, especially on the wide time ranges, and reduces
 amount of data transferred.
 
-Read [how to configure](./sql_datasource) SQL data source in Grafana.
+Read [how to configure](./direct_db_datasource.md) SQL data source in Grafana.
 
 - **Enable**: enable Direct DB Connection.
 - **Data Source**: Select Data Source for Zabbix history database.

--- a/docs/sources/configuration/index.md
+++ b/docs/sources/configuration/index.md
@@ -58,7 +58,7 @@ Direct DB Connection allows plugin to use existing SQL data source for querying 
 database. This way usually faster than pulling data from Zabbix API, especially on the wide time ranges, and reduces
 amount of data transferred.
 
-Read [how to configure](./direct_db_datasource.md) SQL data source in Grafana.
+Read [how to configure](./direct_db_datasource) SQL data source in Grafana.
 
 - **Enable**: enable Direct DB Connection.
 - **Data Source**: Select Data Source for Zabbix history database.


### PR DESCRIPTION
The original linked file in section `Direct DB Connection` is missing,
> Read how to configure SQL data source in Grafana.

change it to [direct_db_datasource](https://github.com/alexanderzobnin/grafana-zabbix/blob/docs/docs/sources/configuration/direct_db_datasource.md)
Fixes #901 
