### PR TITLE
Fix compatibility with Zabbix 5.4 (skip applications filter)

### DIFF
--- a/pkg/datasource/zabbix.go
+++ b/pkg/datasource/zabbix.go
@@ -167,7 +167,10 @@ func (ds *ZabbixDatasourceInstance) getItems(ctx context.Context, groupFilter st
 	}
 
 	apps, err := ds.getApps(ctx, groupFilter, hostFilter, appFilter)
-	if err != nil {
+	// Apps not supported in Zabbix 5.4 and higher
+	if isAppMethodNotFoundError(err) {
+		apps = []map[string]interface{}{}
+	} else if err != nil {
 		return nil, err
 	}
 	var appids []string
@@ -504,4 +507,13 @@ func isNotAuthorized(err error) bool {
 	return strings.Contains(message, "Session terminated, re-login, please.") ||
 		strings.Contains(message, "Not authorised.") ||
 		strings.Contains(message, "Not authorized.")
+}
+
+func isAppMethodNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	message := err.Error()
+	return message == `Method not found. Incorrect API "application".`
 }

--- a/src/datasource-zabbix/partials/query.editor.html
+++ b/src/datasource-zabbix/partials/query.editor.html
@@ -122,6 +122,7 @@
       <label class="gf-form-label query-keyword width-7">Application</label>
       <input type="text"
         ng-model="ctrl.target.application.filter"
+        ng-disabled="ctrl.appFilterDisabled()"
         bs-typeahead="ctrl.getApplicationNames"
         ng-blur="ctrl.onTargetBlur()"
         data-min-length=0

--- a/src/datasource-zabbix/query.controller.ts
+++ b/src/datasource-zabbix/query.controller.ts
@@ -512,4 +512,8 @@ export class ZabbixQueryController extends QueryCtrl {
     this.init();
     this.targetChanged();
   }
+
+  appFilterDisabled() {
+    return !this.zabbix.supportsApplications();
+  }
 }

--- a/src/datasource-zabbix/zabbix/types.ts
+++ b/src/datasource-zabbix/zabbix/types.ts
@@ -19,4 +19,6 @@ export interface ZabbixConnector {
   getApps: (groupFilter?, hostFilter?, appFilter?) => any;
   getItems: (groupFilter?, hostFilter?, appFilter?, itemFilter?, options?) => any;
   getSLA: (itservices, timeRange, target, options?) => any;
+
+  supportsApplications: () => boolean;
 }


### PR DESCRIPTION
This PR fixes #1188 by simply ignoring application filter.
This is only compatibility fix. Tags support will be added in the 4.2 release.