### PR TITLE
Update Grafana troubleshooting docs URL

### DIFF
--- a/docs/sources/configuration/troubleshooting.md
+++ b/docs/sources/configuration/troubleshooting.md
@@ -1,5 +1,5 @@
 # Troubleshooting
-See [Grafana troubleshooting](http://docs.grafana.org/installation/troubleshooting/) for general
+See [Grafana troubleshooting](https://grafana.com/docs/grafana/latest/troubleshooting/) for general
 connection issues. If you have a problem with Zabbix datasource, you should open
 a [support issue](https://github.com/alexanderzobnin/grafana-zabbix/issues). Before you do that
 please search the existing closed or open issues.


### PR DESCRIPTION
Changed http://docs.grafana.org/installation/troubleshooting/
to
https://grafana.com/docs/grafana/latest/troubleshooting/
