### PR TITLE
Use time.Truncate instead of time.Round in GetTimeFrame

### DIFF
--- a/pkg/timeseries/timeseries.go
+++ b/pkg/timeseries/timeseries.go
@@ -30,7 +30,7 @@ func (tsd *TimeSeriesData) Add(point TimePoint) *TimeSeriesData {
 
 // Gets point timestamp rounded according to provided interval.
 func (p *TimePoint) GetTimeFrame(interval time.Duration) time.Time {
-	return p.Time.Round(interval)
+	return p.Time.Truncate(interval)
 }
 
 // GroupBy groups points in given interval by applying provided `aggFunc`. Source time series should be sorted by time.


### PR DESCRIPTION
Fixes #1310

This is required to properly aggregate by full interval.

See:
- Current behavior: https://play.golang.org/p/c6J3EdFp8KC
- Fixed behavior after this PR: https://play.golang.org/p/lustHMtW7ZD