### PR TITLE
Fixes incorrect problem name when PROBLEM event generation mode set to multiple

### DIFF
--- a/src/datasource-zabbix/problemsHandler.ts
+++ b/src/datasource-zabbix/problemsHandler.ts
@@ -23,7 +23,7 @@ export function joinTriggersWithProblems(problems: ZBXProblem[], triggers: ZBXTr
         tags: p.tags,
         suppressed: p.suppressed,
         suppression_data: p.suppression_data,
-        description: t.description,
+        description: p.name || t.description,
         comments: t.comments,
         value: t.value,
         groups: t.groups,


### PR DESCRIPTION
Fixes #1403

After fix
<img width="1155" alt="image" src="https://user-images.githubusercontent.com/153843/156622906-e8acb0ae-0619-41a4-aea8-1545ede2ccee.png">