### PR TITLE
Switch to regexp2 for parseFilter()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/bitly/go-simplejson v0.5.0
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
+	github.com/dlclark/regexp2 v1.4.0
 	github.com/grafana/grafana-plugin-sdk-go v0.133.0
 	github.com/hashicorp/go-hclog v0.16.1 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.4.0 h1:F1rxgk7p4uKjwIQxBs9oAXe5CqrXlCduYEJvrF4u93E=
+github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/elazarl/goproxy v0.0.0-20220115173737-adb46da277ac/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/elazarl/goproxy/ext v0.0.0-20220115173737-adb46da277ac/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=

--- a/pkg/zabbix/methods.go
+++ b/pkg/zabbix/methods.go
@@ -148,7 +148,7 @@ func filterItemsByTag(items []*Item, filter string) ([]*Item, error) {
 			}
 			for _, t := range tags {
 				if re != nil {
-					if re.MatchString(t) {
+					if match, err := re.MatchString(t); match && err != nil {
 						filteredItems = append(filteredItems, i)
 						break
 					}
@@ -173,7 +173,7 @@ func filterItemsByQuery(items []*Item, filter string) ([]*Item, error) {
 	for _, i := range items {
 		name := i.Name
 		if re != nil {
-			if re.MatchString(name) {
+			if match, err := re.MatchString(name); match && err != nil {
 				filteredItems = append(filteredItems, i)
 			}
 		} else if name == filter {
@@ -212,7 +212,7 @@ func filterAppsByQuery(items []Application, filter string) ([]Application, error
 	for _, i := range items {
 		name := i.Name
 		if re != nil {
-			if re.MatchString(name) {
+			if match, err := re.MatchString(name); match && err != nil {
 				filteredItems = append(filteredItems, i)
 			}
 		} else if name == filter {
@@ -251,7 +251,7 @@ func filterHostsByQuery(items []Host, filter string) ([]Host, error) {
 	for _, i := range items {
 		name := i.Name
 		if re != nil {
-			if re.MatchString(name) {
+			if match, err := re.MatchString(name); match && err != nil {
 				filteredItems = append(filteredItems, i)
 			}
 		} else if name == filter {
@@ -282,7 +282,7 @@ func filterGroupsByQuery(items []Group, filter string) ([]Group, error) {
 	for _, i := range items {
 		name := i.Name
 		if re != nil {
-			if re.MatchString(name) {
+			if match, err := re.MatchString(name); match && err != nil {
 				filteredItems = append(filteredItems, i)
 			}
 		} else if name == filter {

--- a/pkg/zabbix/utils.go
+++ b/pkg/zabbix/utils.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/dlclark/regexp2"
 )
 
 func (item *Item) ExpandItemName() string {
@@ -63,9 +65,10 @@ func splitKeyParams(paramStr string) []string {
 	return params
 }
 
-func parseFilter(filter string) (*regexp.Regexp, error) {
-	regex := regexp.MustCompile(`^/(.+)/([imsU]*)$`)
-	flagRE := regexp.MustCompile("[imsU]+")
+func parseFilter(filter string) (*regexp2.Regexp, error) {
+	vaildREModifiers := "imncsxrde"
+	regex := regexp.MustCompile(`^/(.+)/(\w*)$`)
+	flagRE := regexp.MustCompile("[" + vaildREModifiers + "]+")
 
 	matches := regex.FindStringSubmatch(filter)
 	if len(matches) <= 1 {
@@ -77,12 +80,12 @@ func parseFilter(filter string) (*regexp.Regexp, error) {
 		if flagRE.MatchString(matches[2]) {
 			pattern += "(?" + matches[2] + ")"
 		} else {
-			return nil, fmt.Errorf("error parsing regexp: unsupported flags `%s` (expected [imsU])", matches[2])
+			return nil, fmt.Errorf("error parsing regexp: unsupported flags `%s` (expected [%s])", matches[2], vaildREModifiers)
 		}
 	}
 	pattern += matches[1]
 
-	return regexp.Compile(pattern)
+	return regexp2.Compile(pattern, regexp2.RE2)
 }
 
 func itemTagToString(tag ItemTag) string {


### PR DESCRIPTION
I changed the returned regexp of `parseFilter()` to regexp2. I kept all other uses `regexp` since there's no need for a switch and `regexp2` seems to be unnecessary complex to use for something like `FindStringSubmatch()`.
I haven't run any tests on a real grafana instance, I'll try that later. But I extended the tests and they passed.

If there's anything I could/should change, just let me know! :)

This PR should fix #1264 


