### PR TITLE
Fix hostgroup.get in Zabbix 6.2

### DIFF
--- a/devenv/README.md
+++ b/devenv/README.md
@@ -12,6 +12,12 @@ cd devenv/zabbix60
 docker-compose up -d
 ```
 
+Run bootstrap again in case of error:
+
+```shell
+docker-compose up -d --build bootstrap
+```
+
 Grafana will be available at http://localhost:3001 (with default `admin:admin` credentials).
 
 If you want to edit sources, do it, rebuild plugin and then restart grafana container:

--- a/devenv/zabbix62/bootstrap/Dockerfile
+++ b/devenv/zabbix62/bootstrap/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:2.7
+
+ENV ZBX_API_URL=http://zabbix-web:8080
+ENV ZBX_API_USER="Admin"
+ENV ZBX_API_PASSWORD="zabbix"
+ENV ZBX_CONFIG="zbx_export_hosts.xml"
+ENV ZBX_BOOTSTRAP_SCRIPT="bootstrap_config.py"
+
+RUN pip install pyzabbix
+
+ADD ./bootstrap_config.py /bootstrap_config.py
+ADD ${ZBX_CONFIG} /${ZBX_CONFIG}
+
+WORKDIR /
+
+# Run bootstrap_config.py when the container launches
+CMD ["python", "/bootstrap_config.py"]

--- a/devenv/zabbix62/bootstrap/bootstrap_config.py
+++ b/devenv/zabbix62/bootstrap/bootstrap_config.py
@@ -1,0 +1,80 @@
+import os
+from time import sleep
+from pyzabbix import ZabbixAPI, ZabbixAPIException
+
+zabbix_url = os.environ['ZBX_API_URL']
+zabbix_user = os.environ['ZBX_API_USER']
+zabbix_password = os.environ['ZBX_API_PASSWORD']
+print(zabbix_url, zabbix_user, zabbix_password)
+
+zapi = ZabbixAPI(zabbix_url, timeout=5)
+
+for i in range(10):
+  print("Trying to connected to Zabbix API %s" % zabbix_url)
+  try:
+    zapi.login(zabbix_user, zabbix_password)
+    print("Connected to Zabbix API Version %s" % zapi.api_version())
+    break
+  except ZabbixAPIException as e:
+    print e
+    sleep(5)
+  except:
+    print("Waiting")
+    sleep(5)
+
+
+config_path = os.environ['ZBX_CONFIG']
+import_rules = {
+  'discoveryRules': {
+      'createMissing': True,
+      'updateExisting': True
+  },
+  'graphs': {
+      'createMissing': True,
+      'updateExisting': True
+  },
+  'host_groups': {
+      'createMissing': True
+  },
+  'hosts': {
+      'createMissing': True,
+      'updateExisting': True
+  },
+  'images': {
+      'createMissing': True,
+      'updateExisting': True
+  },
+  'items': {
+      'createMissing': True,
+      'updateExisting': True
+  },
+  'maps': {
+      'createMissing': True,
+      'updateExisting': True
+  },
+  'templateLinkage': {
+      'createMissing': True,
+  },
+  'templates': {
+      'createMissing': True,
+      'updateExisting': True
+  },
+  'triggers': {
+      'createMissing': True,
+      'updateExisting': True
+  },
+}
+
+print("Importing Zabbix config from %s" % config_path)
+with open(config_path, 'r') as f:
+  config = f.read()
+
+  try:
+    # https://github.com/lukecyca/pyzabbix/issues/62
+    import_result = zapi.confimport("xml", config, import_rules)
+    print(import_result)
+  except ZabbixAPIException as e:
+    print e
+
+for h in zapi.host.get(output="extend"):
+    print(h['name'])

--- a/devenv/zabbix62/bootstrap/zbx_export_hosts.xml
+++ b/devenv/zabbix62/bootstrap/zbx_export_hosts.xml
@@ -1,0 +1,432 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<zabbix_export>
+    <version>6.2</version>
+    <date>2022-04-28T13:04:18Z</date>
+    <host_groups>
+        <host_group>
+            <uuid>2e427c268ac1468b9add94b65e2d6c14</uuid>
+            <name>Backend</name>
+        </host_group>
+        <host_group>
+            <uuid>d97ba66b283544339628b71975a6e68d</uuid>
+            <name>Frontend</name>
+        </host_group>
+        <host_group>
+            <uuid>dc579cd7a1a34222933f24f52a68bcd8</uuid>
+            <name>Linux servers</name>
+        </host_group>
+        <host_group>
+            <uuid>6f6799aa69e844b4b3918f779f2abf08</uuid>
+            <name>Zabbix servers</name>
+        </host_group>
+        <host_group>
+            <uuid>7df96b18c230490a9a0a9e2307226338</uuid>
+            <name>Templates</name>
+        </host_group>
+    </host_groups>
+    <hosts>
+        <host>
+            <host>backend01</host>
+            <name>backend01</name>
+            <templates>
+                <template>
+                    <name>Template ZAS Agent</name>
+                </template>
+            </templates>
+            <groups>
+                <group>
+                    <name>Backend</name>
+                </group>
+                <group>
+                    <name>Linux servers</name>
+                </group>
+            </groups>
+            <interfaces>
+                <interface>
+                    <useip>NO</useip>
+                    <dns>zas_backend_01</dns>
+                    <interface_ref>if1</interface_ref>
+                </interface>
+            </interfaces>
+            <tags>
+                <tag>
+                    <tag>backend</tag>
+                </tag>
+                <tag>
+                    <tag>service</tag>
+                    <value>backend</value>
+                </tag>
+            </tags>
+            <inventory_mode>DISABLED</inventory_mode>
+        </host>
+        <host>
+            <host>backend02</host>
+            <name>backend02</name>
+            <templates>
+                <template>
+                    <name>Template ZAS Agent</name>
+                </template>
+            </templates>
+            <groups>
+                <group>
+                    <name>Backend</name>
+                </group>
+                <group>
+                    <name>Linux servers</name>
+                </group>
+            </groups>
+            <interfaces>
+                <interface>
+                    <useip>NO</useip>
+                    <dns>zas_backend_02</dns>
+                    <interface_ref>if1</interface_ref>
+                </interface>
+            </interfaces>
+            <tags>
+                <tag>
+                    <tag>backend</tag>
+                </tag>
+                <tag>
+                    <tag>service</tag>
+                    <value>backend</value>
+                </tag>
+            </tags>
+            <inventory_mode>DISABLED</inventory_mode>
+        </host>
+        <host>
+            <host>frontend01</host>
+            <name>frontend01</name>
+            <templates>
+                <template>
+                    <name>Template ZAS Agent</name>
+                </template>
+            </templates>
+            <groups>
+                <group>
+                    <name>Frontend</name>
+                </group>
+                <group>
+                    <name>Linux servers</name>
+                </group>
+            </groups>
+            <interfaces>
+                <interface>
+                    <useip>NO</useip>
+                    <dns>zas_frontend_01</dns>
+                    <interface_ref>if1</interface_ref>
+                </interface>
+            </interfaces>
+            <tags>
+                <tag>
+                    <tag>frontend</tag>
+                </tag>
+                <tag>
+                    <tag>service</tag>
+                    <value>frontend</value>
+                </tag>
+            </tags>
+            <inventory_mode>DISABLED</inventory_mode>
+        </host>
+        <host>
+            <host>frontend02</host>
+            <name>frontend02</name>
+            <templates>
+                <template>
+                    <name>Template ZAS Agent</name>
+                </template>
+            </templates>
+            <groups>
+                <group>
+                    <name>Frontend</name>
+                </group>
+                <group>
+                    <name>Linux servers</name>
+                </group>
+            </groups>
+            <interfaces>
+                <interface>
+                    <useip>NO</useip>
+                    <dns>zas_frontend_02</dns>
+                    <interface_ref>if1</interface_ref>
+                </interface>
+            </interfaces>
+            <tags>
+                <tag>
+                    <tag>frontend</tag>
+                </tag>
+                <tag>
+                    <tag>service</tag>
+                    <value>frontend</value>
+                </tag>
+            </tags>
+            <inventory_mode>DISABLED</inventory_mode>
+        </host>
+        <host>
+            <host>Zabbix server</host>
+            <name>Zabbix server</name>
+            <templates>
+                <template>
+                    <name>Linux by Zabbix agent</name>
+                </template>
+                <template>
+                    <name>Zabbix server health</name>
+                </template>
+            </templates>
+            <groups>
+                <group>
+                    <name>Zabbix servers</name>
+                </group>
+            </groups>
+            <interfaces>
+                <interface>
+                    <useip>NO</useip>
+                    <dns>zabbix-agent</dns>
+                    <interface_ref>if1</interface_ref>
+                </interface>
+            </interfaces>
+            <inventory_mode>DISABLED</inventory_mode>
+        </host>
+    </hosts>
+    <templates>
+        <template>
+            <uuid>2d7a65bb369c48199361913b223b1695</uuid>
+            <template>Template ZAS Agent</template>
+            <name>Template ZAS Agent</name>
+            <templates>
+                <template>
+                    <name>Zabbix agent</name>
+                </template>
+            </templates>
+            <groups>
+                <group>
+                    <name>Templates</name>
+                </group>
+            </groups>
+            <items>
+                <item>
+                    <uuid>e79d4215ec014b74923b905bb8f82410</uuid>
+                    <name>Incoming network traffic on eth0</name>
+                    <key>net.if.in[eth0]</key>
+                    <history>1d</history>
+                    <units>bps</units>
+                    <request_method>POST</request_method>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Network interfaces</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>18b377dae9fe48d093c16ee7a7c93320</uuid>
+                    <name>Outgoing network traffic on eth0</name>
+                    <key>net.if.out[eth0]</key>
+                    <history>1d</history>
+                    <units>bps</units>
+                    <request_method>POST</request_method>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Network interfaces</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>2479e055e91c476f9be93b5f363cfa2f</uuid>
+                    <name>Processor load (1 min average per core)</name>
+                    <key>system.cpu.load[percpu,avg1]</key>
+                    <history>1d</history>
+                    <value_type>FLOAT</value_type>
+                    <description>The processor load is calculated as system CPU load divided by number of CPU cores.</description>
+                    <request_method>POST</request_method>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>CPU</value>
+                        </tag>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Performance</value>
+                        </tag>
+                    </tags>
+                    <triggers>
+                        <trigger>
+                            <uuid>60e5484b60ca4061b21bd23f8364bd6e</uuid>
+                            <expression>last(/Template ZAS Agent/system.cpu.load[percpu,avg1])&gt;2</expression>
+                            <name>Processor load is too high on {HOST.NAME}</name>
+                            <priority>WARNING</priority>
+                            <tags>
+                                <tag>
+                                    <tag>app</tag>
+                                    <value>performance</value>
+                                </tag>
+                                <tag>
+                                    <tag>type</tag>
+                                    <value>cpu</value>
+                                </tag>
+                            </tags>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <uuid>f0dd4221793c49889cf2789806afa597</uuid>
+                    <name>Processor load (15 min average per core)</name>
+                    <key>system.cpu.load[percpu,avg15]</key>
+                    <history>1d</history>
+                    <value_type>FLOAT</value_type>
+                    <description>The processor load is calculated as system CPU load divided by number of CPU cores.</description>
+                    <request_method>POST</request_method>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>CPU</value>
+                        </tag>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Performance</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>9a8b4a1f173b4f209723d820dc2e054a</uuid>
+                    <name>CPU $2 time</name>
+                    <key>system.cpu.util[,iowait]</key>
+                    <history>1d</history>
+                    <value_type>FLOAT</value_type>
+                    <units>%</units>
+                    <description>Amount of time the CPU has been waiting for I/O to complete.</description>
+                    <request_method>POST</request_method>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>CPU</value>
+                        </tag>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Performance</value>
+                        </tag>
+                    </tags>
+                    <triggers>
+                        <trigger>
+                            <uuid>ceb468b9eb434fa6bd4c8a5d7507fd87</uuid>
+                            <expression>avg(/Template ZAS Agent/system.cpu.util[,iowait],5m)&gt;20</expression>
+                            <name>Disk I/O is overloaded on {HOST.NAME}</name>
+                            <priority>WARNING</priority>
+                            <description>OS spends significant time waiting for I/O (input/output) operations. It could be indicator of performance issues with storage system.</description>
+                            <tags>
+                                <tag>
+                                    <tag>disk</tag>
+                                </tag>
+                                <tag>
+                                    <tag>type</tag>
+                                    <value>disk</value>
+                                </tag>
+                            </tags>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <uuid>e6d19d47cf60452ead1e791da2d5c0dc</uuid>
+                    <name>CPU $2 time</name>
+                    <key>system.cpu.util[,system]</key>
+                    <history>1d</history>
+                    <value_type>FLOAT</value_type>
+                    <units>%</units>
+                    <description>The time the CPU has spent running the kernel and its processes.</description>
+                    <request_method>POST</request_method>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>CPU</value>
+                        </tag>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Performance</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>2d81fbc139774306959712a627c99b9a</uuid>
+                    <name>CPU $2 time</name>
+                    <key>system.cpu.util[,user]</key>
+                    <history>1d</history>
+                    <value_type>FLOAT</value_type>
+                    <units>%</units>
+                    <description>The time the CPU has spent running users' processes that are not niced.</description>
+                    <request_method>POST</request_method>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>CPU</value>
+                        </tag>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Performance</value>
+                        </tag>
+                    </tags>
+                </item>
+            </items>
+        </template>
+    </templates>
+    <graphs>
+        <graph>
+            <uuid>7aac0ec0c0e04b7a8bb6472d1faa7a09</uuid>
+            <name>CPU load</name>
+            <ymin_type_1>FIXED</ymin_type_1>
+            <graph_items>
+                <graph_item>
+                    <color>009900</color>
+                    <item>
+                        <host>Template ZAS Agent</host>
+                        <key>system.cpu.load[percpu,avg1]</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>2</sortorder>
+                    <color>990000</color>
+                    <item>
+                        <host>Template ZAS Agent</host>
+                        <key>system.cpu.load[percpu,avg15]</key>
+                    </item>
+                </graph_item>
+            </graph_items>
+        </graph>
+        <graph>
+            <uuid>f25064d88b964a678fac7ea6095b238a</uuid>
+            <name>CPU utilization</name>
+            <show_triggers>NO</show_triggers>
+            <type>STACKED</type>
+            <ymin_type_1>FIXED</ymin_type_1>
+            <ymax_type_1>FIXED</ymax_type_1>
+            <graph_items>
+                <graph_item>
+                    <sortorder>4</sortorder>
+                    <drawtype>FILLED_REGION</drawtype>
+                    <color>999900</color>
+                    <item>
+                        <host>Template ZAS Agent</host>
+                        <key>system.cpu.util[,iowait]</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>5</sortorder>
+                    <drawtype>FILLED_REGION</drawtype>
+                    <color>990000</color>
+                    <item>
+                        <host>Template ZAS Agent</host>
+                        <key>system.cpu.util[,system]</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>6</sortorder>
+                    <drawtype>FILLED_REGION</drawtype>
+                    <color>000099</color>
+                    <item>
+                        <host>Template ZAS Agent</host>
+                        <key>system.cpu.util[,user]</key>
+                    </item>
+                </graph_item>
+            </graph_items>
+        </graph>
+    </graphs>
+</zabbix_export>

--- a/devenv/zabbix62/docker-compose.yml
+++ b/devenv/zabbix62/docker-compose.yml
@@ -1,0 +1,119 @@
+version: "3"
+
+services:
+  # Grafana
+  grafana:
+    image: grafana/grafana:8.4.7
+    ports:
+      - "3001:3000"
+    volumes:
+      - ../..:/grafana-zabbix
+      - ../dashboards:/devenv/dashboards
+      - ../grafana.ini:/etc/grafana/grafana.ini:ro
+      - "../datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml"
+      - "../dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml"
+
+  # Zabbix
+  zabbix-server:
+    image: zabbix/zabbix-server-pgsql:alpine-6.2-latest
+    ports:
+      - "10051:10051"
+    depends_on:
+      - database
+    environment:
+      DB_SERVER_HOST: database
+      DB_SERVER_PORT: 5432
+      POSTGRES_USER: zabbix
+      POSTGRES_PASSWORD: zabbix
+      POSTGRES_DB: zabbix
+      ZBX_TIMEOUT: 10
+      ZBX_STARTPOLLERS: 10
+      ZBX_STARTPOLLERSUNREACHABLE: 5
+      ZBX_DEBUGLEVEL: 3
+
+  zabbix-web:
+    image: zabbix/zabbix-web-apache-pgsql:alpine-6.2-latest
+    ports:
+      - "8188:8080"
+    depends_on:
+      - database
+      - zabbix-server
+    environment:
+      ZBX_SERVER_HOST: zabbix-server
+      ZBX_SERVER_PORT: 10051
+      DB_SERVER_HOST: database
+      DB_SERVER_PORT: 5432
+      POSTGRES_USER: zabbix
+      POSTGRES_PASSWORD: zabbix
+      POSTGRES_DB: zabbix
+
+  database:
+    image: postgres
+    ports:
+      - "15432:5432"
+    command: postgres -c 'max_connections=1000'
+    environment:
+      POSTGRES_USER: zabbix
+      POSTGRES_PASSWORD: zabbix
+
+  zabbix-agent:
+    image: zabbix/zabbix-agent:alpine-6.2-latest
+    environment:
+      ZBX_SERVER_HOST: zabbix-server
+      ZBX_SERVER_PORT: 10051
+
+  #########################################################
+  # Bootstrap config
+  #########################################################
+
+  bootstrap:
+    build: ./bootstrap
+    environment:
+      ZBX_API_URL: http://zabbix-web:8080
+      ZBX_API_USER: Admin
+      ZBX_API_PASSWORD: zabbix
+    depends_on:
+      - database
+      - zabbix-server
+      - zabbix-web
+
+  #########################################################
+  # Fake agents
+  #########################################################
+
+  # backend
+  redis_backend:
+    image: redis:alpine
+
+  zas_backend_01:
+    build: ../zas-agent
+    volumes:
+      - ../zas-agent/conf/zas_scenario_backend.cfg:/etc/zas_scenario.cfg
+    environment:
+      REDIS_HOST: redis_backend
+    # restart: always
+
+  zas_backend_02:
+    build: ../zas-agent
+    volumes:
+      - ../zas-agent/conf/zas_scenario_backend.cfg:/etc/zas_scenario.cfg
+    environment:
+      REDIS_HOST: redis_backend
+
+  # frontend
+  redis_frontend:
+    image: redis:alpine
+
+  zas_frontend_01:
+    build: ../zas-agent
+    volumes:
+      - ../zas-agent/conf/zas_scenario_frontend.cfg:/etc/zas_scenario.cfg
+    environment:
+      REDIS_HOST: redis_frontend
+
+  zas_frontend_02:
+    build: ../zas-agent
+    volumes:
+      - ../zas-agent/conf/zas_scenario_frontend.cfg:/etc/zas_scenario.cfg
+    environment:
+      REDIS_HOST: redis_frontend

--- a/pkg/zabbix/methods.go
+++ b/pkg/zabbix/methods.go
@@ -393,7 +393,7 @@ func (ds *Zabbix) GetAllHosts(ctx context.Context, groupids []string) ([]Host, e
 
 func (ds *Zabbix) GetAllGroups(ctx context.Context) ([]Group, error) {
 	params := ZabbixAPIParams{
-		"output":     []string{"name"},
+		"output":     []string{"name", "groupid"},
 		"sortfield":  "name",
 		"real_hosts": true,
 	}

--- a/pkg/zabbix/methods.go
+++ b/pkg/zabbix/methods.go
@@ -376,7 +376,7 @@ func (ds *Zabbix) GetAllApps(ctx context.Context, hostids []string) ([]Applicati
 
 func (ds *Zabbix) GetAllHosts(ctx context.Context, groupids []string) ([]Host, error) {
 	params := ZabbixAPIParams{
-		"output":    []string{"name", "host"},
+		"output":    []string{"hostid", "name", "host"},
 		"sortfield": "name",
 		"groupids":  groupids,
 	}

--- a/src/datasource-zabbix/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
+++ b/src/datasource-zabbix/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
@@ -144,7 +144,7 @@ export class ZabbixAPIConnector {
 
   getHosts(groupids) {
     const params: any = {
-      output: ['name', 'host'],
+      output: ['hostid', 'name', 'host'],
       sortfield: 'name'
     };
     if (groupids) {
@@ -177,6 +177,7 @@ export class ZabbixAPIConnector {
   getItems(hostids, appids, itemtype) {
     const params: any = {
       output: [
+        'itemid',
         'name',
         'key_',
         'value_type',
@@ -219,6 +220,7 @@ export class ZabbixAPIConnector {
     const params: any = {
       itemids: itemids,
       output: [
+        'itemid',
         'name',
         'key_',
         'value_type',
@@ -342,8 +344,9 @@ export class ZabbixAPIConnector {
     const itemids = _.map(items, 'itemid');
 
     const params: any = {
-      output: ["itemid",
-        "clock",
+      output: [
+        'itemid',
+        'clock',
         value_type
       ],
       itemids: itemids,
@@ -498,8 +501,8 @@ export class ZabbixAPIConnector {
       monitored: true,
       skipDependent: true,
       selectGroups: ['name', 'groupid'],
-      selectHosts: ['name', 'host', 'maintenance_status', 'proxy_hostid'],
-      selectItems: ['name', 'key_', 'lastvalue'],
+      selectHosts: ['hostid', 'name', 'host', 'maintenance_status', 'proxy_hostid'],
+      selectItems: ['itemid', 'name', 'key_', 'lastvalue'],
       // selectLastEvent: 'extend',
       // selectTags: 'extend',
       preservekeys: '1',
@@ -525,9 +528,9 @@ export class ZabbixAPIConnector {
       filter: {
         value: 1
       },
-      selectGroups: ['name', 'groupid'],
-      selectHosts: ['name', 'host', 'maintenance_status', 'proxy_hostid'],
-      selectItems: ['name', 'key_', 'lastvalue'],
+      selectGroups: ['groupid', 'name'],
+      selectHosts: ['hostid', 'name', 'host', 'maintenance_status', 'proxy_hostid'],
+      selectItems: ['itemid', 'name', 'key_', 'lastvalue'],
       selectLastEvent: 'extend',
       selectTags: 'extend'
     };
@@ -624,6 +627,7 @@ export class ZabbixAPIConnector {
     const params = {
       eventids: eventids,
       output: [
+        'alertid',
         'eventid',
         'message',
         'clock',
@@ -689,7 +693,7 @@ export class ZabbixAPIConnector {
       skipDependent: true,
       selectLastEvent: 'extend',
       selectGroups: 'extend',
-      selectHosts: ['host', 'name']
+      selectHosts: ['hostid', 'host', 'name']
     };
 
     if (count && acknowledged !== 0 && acknowledged !== 1) {

--- a/src/datasource-zabbix/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
+++ b/src/datasource-zabbix/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
@@ -497,7 +497,7 @@ export class ZabbixAPIConnector {
       expandComment: true,
       monitored: true,
       skipDependent: true,
-      selectGroups: ['name'],
+      selectGroups: ['name', 'groupid'],
       selectHosts: ['name', 'host', 'maintenance_status', 'proxy_hostid'],
       selectItems: ['name', 'key_', 'lastvalue'],
       // selectLastEvent: 'extend',
@@ -525,7 +525,7 @@ export class ZabbixAPIConnector {
       filter: {
         value: 1
       },
-      selectGroups: ['name'],
+      selectGroups: ['name', 'groupid'],
       selectHosts: ['name', 'host', 'maintenance_status', 'proxy_hostid'],
       selectItems: ['name', 'key_', 'lastvalue'],
       selectLastEvent: 'extend',

--- a/src/datasource-zabbix/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
+++ b/src/datasource-zabbix/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
@@ -134,7 +134,7 @@ export class ZabbixAPIConnector {
 
   getGroups() {
     const params = {
-      output: ['name'],
+      output: ['name', 'groupid'],
       sortfield: 'name',
       real_hosts: true
     };


### PR DESCRIPTION
This PR fixes #1470 by adding `groupid` param explicitly to host groups queries.