### PR TITLE
Build for FreeBSD amd64 & arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,9 @@ build-debug:
 
 # Build for specific platform
 build-backend-windows: extension = .exe
-build-backend-darwin-arm64:
-	env GOOS=darwin GOARCH=arm64 go build -o ./dist/zabbix-plugin_darwin_arm64 ./pkg
+build-backend-%-arm64:
+	$(eval filename = zabbix-plugin_$*_arm64$(extension))
+	env GOOS=$* GOARCH=arm64 go build -o ./dist/$(filename) ./pkg
 build-backend-%:
 	$(eval filename = zabbix-plugin_$*_amd64$(extension))
 	env GOOS=$* GOARCH=amd64 go build -o ./dist/$(filename) ./pkg
@@ -41,22 +42,21 @@ dist: dist-frontend dist-backend
 dist-frontend:
 	yarn build
 
-dist-backend: dist-backend-linux dist-backend-darwin dist-backend-windows dist-arm
+dist-backend: dist-backend-linux dist-backend-darwin dist-backend-freebsd dist-backend-windows dist-arm
 dist-backend-windows: extension = .exe
 dist-backend-%:
 	$(eval filename = zabbix-plugin_$*_amd64$(extension))
 	env GOOS=$* GOARCH=amd64 go build -ldflags="-s -w" -o ./dist/$(filename) ./pkg
 
 # ARM
-dist-arm: dist-arm-linux-arm-v6 dist-arm-linux-arm64 dist-arm-darwin-arm64
+dist-arm: dist-arm-linux-arm-v6 dist-arm-linux-arm64 dist-arm-darwin-arm64 dist-arm-freebsd-arm64
 dist-arm-linux-arm-v6:
 	env GOOS=linux GOARCH=arm GOARM=6 go build -ldflags="-s -w" -o ./dist/zabbix-plugin_linux_arm ./pkg
 dist-arm-linux-arm-v7:
 	env GOOS=linux GOARCH=arm GOARM=7 go build -ldflags="-s -w" -o ./dist/zabbix-plugin_linux_arm ./pkg
-dist-arm-linux-arm64:
-	env GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o ./dist/zabbix-plugin_linux_arm64 ./pkg
-dist-arm-darwin-arm64:
-	env GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w" -o ./dist/zabbix-plugin_darwin_arm64 ./pkg
+dist-arm-%-arm64:
+	$(eval filename = zabbix-plugin_$*_arm64$(extension))
+	env GOOS=$* GOARCH=arm64 go build -ldflags="-s -w" -o ./dist/$(filename) ./pkg
 
 .PHONY: test
 test: test-frontend test-backend


### PR DESCRIPTION
Both architectures supported by Go on FreeBSD.

Slightly simplified Makefile to avoid repeating same build commands for every variation of `GOOS`/`GOARCH`.

Fixes #1301, fixes #1402, fixes #1237, and fixes #1203.
