### PR TITLE
Fix deprecated /auth zabbix version

### DIFF
--- a/pkg/zabbixapi/zabbix_api.go
+++ b/pkg/zabbixapi/zabbix_api.go
@@ -98,7 +98,7 @@ func (api *ZabbixAPI) request(ctx context.Context, method string, params ZabbixA
 		"params":  normalizeParams(ctx, method, params, version),
 	}
 
-	// Zabbix v7.2 and later deprecated `auth` parameter and replaced it with using Auth header
+	// Zabbix v6.4 and later deprecated `auth` parameter and replaced it with using Auth header
 	// `auth` parameter throws an error in new versions so we need to add it only for older versions
 	if auth != "" && version < 64 {
 		apiRequest["auth"] = auth


### PR DESCRIPTION
I guess it closes https://github.com/grafana/grafana-zabbix/issues/2038