### PR TITLE
release prep : 6.2.1

### DIFF
--- a/.changeset/dark-moles-fall.md
+++ b/.changeset/dark-moles-fall.md
@@ -1,5 +1,0 @@
----
-'grafana-zabbix': patch
----
-
-Fix problem description text overflow by adding white-space: normal to prevent layout issues with acknowledgment panel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,33 @@
 # Change Log
 
+## 6.2.1
+
+🐛 Fix problem description text overflow by adding `white-space: normal` to prevent layout issues with acknowledgment panel
+
+⚙️ Updated backend/go version to 1.26.0 from 1.25.6 which resolves CVE-2025-68121
+
+⚙️ Updated frontend & backend dependencies
+
 ## 6.2.0
 
 🚀 Update dependencies for react-19 upgrade preparations
+
 🐛 Fix: Show disabled items in directdb connection
+
 🐛 Fix service query when selecting an SLA value
 
 ## 6.1.2
 
 🐛 Fix silent removal of itemTagFilter when no tags match regex
+
 🐛 Enhance the problems panel with the ability to convert specific tags to columns. Single or multiple tags supported.
+
 🐛 Fix column visibility toggles for problems panel
 
 ## 6.1.1
 
 🐛 Fix moment value rendering issue
+
 🐛 Fix proxies dropdown in ProblemsQueryEditor
 
 ## 6.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-zabbix",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "Zabbix plugin for Grafana",
   "homepage": "http://grafana-zabbix.org",
   "bugs": {


### PR DESCRIPTION
bumped the version ( missed in https://github.com/grafana/grafana-zabbix/pull/2323 )