### PR TITLE
Interpolate item value item lastvalue in description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Change Log
 
+## 6.3.2
+
+🐛 Fix `{ITEM.VALUE}` and `{ITEM.LASTVALUE}` macros in trigger description always showing the current item value instead of the value at problem creation time
+
 ## 6.3.1
 
-🐛 Fix problems panel showing identical operational data for all problems of the same trigger by fetching historical item values at each problem's timestamp instead of the current `lastvalue`
+🐛 Fix operational data showing the same current item value for all problems of the same trigger; historical item values are now fetched at each problem's timestamp via `history.get`
 
 ## 6.3.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-zabbix",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "description": "Zabbix plugin for Grafana",
   "homepage": "http://grafana-zabbix.org",
   "bugs": {

--- a/src/datasource/problemsHandler.test.ts
+++ b/src/datasource/problemsHandler.test.ts
@@ -28,10 +28,9 @@ describe('expandItemMacros', () => {
   });
 
   it('expands both macros in the same string with different values', () => {
-    const result = expandItemMacros(
-      'Value received: {ITEM.VALUE} / Last value received: {ITEM.LASTVALUE}',
-      [item('12', '7')]
-    );
+    const result = expandItemMacros('Value received: {ITEM.VALUE} / Last value received: {ITEM.LASTVALUE}', [
+      item('12', '7'),
+    ]);
     expect(result).toBe('Value received: 12 / Last value received: 7');
   });
 

--- a/src/datasource/problemsHandler.test.ts
+++ b/src/datasource/problemsHandler.test.ts
@@ -1,0 +1,69 @@
+import { expandItemMacros } from './problemsHandler';
+
+describe('expandItemMacros', () => {
+  const item = (historicalValue?: string, originalLastvalue?: string) => ({ historicalValue, originalLastvalue });
+
+  describe('{ITEM.VALUE}', () => {
+    it('replaces with historicalValue when available', () => {
+      expect(expandItemMacros('Value: {ITEM.VALUE}', [item('12', '7')])).toBe('Value: 12');
+    });
+
+    it('falls back to originalLastvalue when historicalValue is undefined', () => {
+      expect(expandItemMacros('Value: {ITEM.VALUE}', [item(undefined, '7')])).toBe('Value: 7');
+    });
+
+    it('replaces all occurrences', () => {
+      expect(expandItemMacros('{ITEM.VALUE} / {ITEM.VALUE}', [item('12', '7')])).toBe('12 / 12');
+    });
+  });
+
+  describe('{ITEM.LASTVALUE}', () => {
+    it('always uses originalLastvalue, not historicalValue', () => {
+      expect(expandItemMacros('Last: {ITEM.LASTVALUE}', [item('12', '7')])).toBe('Last: 7');
+    });
+
+    it('expands to empty string when originalLastvalue is undefined', () => {
+      expect(expandItemMacros('Last: {ITEM.LASTVALUE}', [item('12', undefined)])).toBe('Last: ');
+    });
+  });
+
+  it('expands both macros in the same string with different values', () => {
+    const result = expandItemMacros(
+      'Value received: {ITEM.VALUE} / Last value received: {ITEM.LASTVALUE}',
+      [item('12', '7')]
+    );
+    expect(result).toBe('Value received: 12 / Last value received: 7');
+  });
+
+  describe('indexed macros', () => {
+    it('expands {ITEM1.VALUE} for first item', () => {
+      expect(expandItemMacros('{ITEM1.VALUE}', [item('4', '7'), item('9', '7')])).toBe('4');
+    });
+
+    it('expands {ITEM2.VALUE} for second item', () => {
+      expect(expandItemMacros('{ITEM2.VALUE}', [item('4', '7'), item('9', '7')])).toBe('9');
+    });
+
+    it('expands {ITEM2.LASTVALUE} for second item', () => {
+      expect(expandItemMacros('{ITEM2.LASTVALUE}', [item('4', '3'), item('9', '7')])).toBe('7');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty string unchanged', () => {
+      expect(expandItemMacros('', [item('12', '7')])).toBe('');
+    });
+
+    it('returns text unchanged when items array is empty', () => {
+      expect(expandItemMacros('Value: {ITEM.VALUE}', [])).toBe('Value: {ITEM.VALUE}');
+    });
+
+    it('returns text unchanged when no macros present', () => {
+      expect(expandItemMacros('no macros here', [item('12', '7')])).toBe('no macros here');
+    });
+
+    it('handles undefined text', () => {
+      expect(expandItemMacros(undefined as any, [item('12', '7')])).toBeUndefined();
+    });
+  });
+});

--- a/src/datasource/problemsHandler.ts
+++ b/src/datasource/problemsHandler.ts
@@ -228,6 +228,27 @@ export function toDataFrame(problems: any[], query: ZabbixMetricsQuery): DataFra
   return response;
 }
 
+interface ItemResolution {
+  historicalValue?: string;
+  originalLastvalue?: string;
+}
+
+export function expandItemMacros(text: string, items: ItemResolution[]): string {
+  if (!text || !items.length) {
+    return text;
+  }
+  let result = text;
+  const first = items[0];
+  result = result.replace(/\{ITEM\.VALUE\}/g, first.historicalValue ?? first.originalLastvalue ?? '');
+  result = result.replace(/\{ITEM\.LASTVALUE\}/g, first.originalLastvalue ?? '');
+  items.forEach(({ historicalValue, originalLastvalue }, index) => {
+    const n = index + 1;
+    result = result.replace(new RegExp(`\\{ITEM${n}\\.VALUE\\}`, 'g'), historicalValue ?? originalLastvalue ?? '');
+    result = result.replace(new RegExp(`\\{ITEM${n}\\.LASTVALUE\\}`, 'g'), originalLastvalue ?? '');
+  });
+  return result;
+}
+
 const problemsHandler = {
   addTriggerDataSource,
   addTriggerHostProxy,

--- a/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
+++ b/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
@@ -567,7 +567,6 @@ export class ZabbixAPIConnector {
       triggerids: triggerids,
       expandDescription: true,
       expandData: true,
-      expandComment: true,
       expandExpression: true,
       monitored: true,
       skipDependent: true,

--- a/src/datasource/zabbix/zabbix.ts
+++ b/src/datasource/zabbix/zabbix.ts
@@ -4,7 +4,7 @@ import _ from 'lodash';
 // eslint-disable-next-line
 import moment from 'moment';
 import semver from 'semver';
-import { joinTriggersWithEvents, joinTriggersWithProblems } from '../problemsHandler';
+import { expandItemMacros, joinTriggersWithEvents, joinTriggersWithProblems } from '../problemsHandler';
 import responseHandler, { handleMultiSLIResponse, handleServiceResponse, handleSLIResponse } from '../responseHandler';
 import { ProblemDTO, ZBXApp, ZBXHost, ZBXItem, ZBXItemTag, ZBXTrigger } from '../types';
 import { ZabbixDSOptions } from '../types/config';
@@ -507,14 +507,37 @@ export class Zabbix implements ZabbixConnector {
     const history = await this.zabbixAPI.getHistory(itemsWithType, timeFrom, timeTill);
     const historyByItem = _.groupBy(history, 'itemid');
 
-    return problems.map((problem) => ({
-      ...problem,
-      items: problem.items?.map((item) => {
+    return problems.map((problem) => {
+      const itemResolutions = (problem.items || []).map((item) => {
         const itemHistory = historyByItem[item.itemid] || [];
         const atTime = _.findLast(itemHistory, (h) => Number(h.clock) <= problem.timestamp);
-        return atTime ? { ...item, lastvalue: atTime.value } : item;
-      }),
-    }));
+        return {
+          originalLastvalue: item.lastvalue,
+          historicalValue: atTime?.value,
+          updatedItem: atTime ? { ...item, lastvalue: atTime.value } : item,
+        };
+      });
+
+      const expandMacros = (text: string): string => {
+        if (!text) {
+          return text;
+        }
+        let result = text;
+        const host = problem.hosts?.[0];
+        if (host) {
+          result = result.replace(/\{HOST\.NAME\}/g, host.name || '');
+          result = result.replace(/\{HOST\.HOST\}/g, host.host || '');
+        }
+        return expandItemMacros(result, itemResolutions);
+      };
+
+      return {
+        ...problem,
+        description: expandMacros(problem.description),
+        comments: expandMacros(problem.comments),
+        items: itemResolutions.map((r) => r.updatedItem),
+      };
+    });
   }
 
   getProblems(groupFilter, hostFilter, appFilter, proxyFilter?, options?): Promise<ProblemDTO[]> {

--- a/tests/e2e/smoke.test.ts
+++ b/tests/e2e/smoke.test.ts
@@ -3,6 +3,5 @@ import { test, expect } from '@grafana/plugin-e2e';
 test('Smoke test: plugin loads', async ({ createDataSourceConfigPage, page }) => {
   await createDataSourceConfigPage({ type: 'alexanderzobnin-zabbix-datasource' });
 
-  await expect(await page.getByText('Zabbix', { exact: true })).toBeVisible();
-  await expect(await page.getByRole('heading', { name: 'Connection', exact: true })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Zabbix Connection' })).toBeVisible();
 });

--- a/tests/e2e/smoke.test.ts
+++ b/tests/e2e/smoke.test.ts
@@ -3,6 +3,6 @@ import { test, expect } from '@grafana/plugin-e2e';
 test('Smoke test: plugin loads', async ({ createDataSourceConfigPage, page }) => {
   await createDataSourceConfigPage({ type: 'alexanderzobnin-zabbix-datasource' });
 
-  await expect(await page.getByText('Type: Zabbix', { exact: true })).toBeVisible();
+  await expect(await page.getByText('Zabbix', { exact: true })).toBeVisible();
   await expect(await page.getByRole('heading', { name: 'Connection', exact: true })).toBeVisible();
 });


### PR DESCRIPTION
Follow-up on https://github.com/grafana/grafana-zabbix/issues/1832

## Summary

- Root cause: The Problems panel displayed the same value for {ITEM.VALUE} in operational data and trigger description across all problems belonging to the same trigger. trigger.get returns a single current lastvalue for each item, shared across every problem event regardless of when it occurred. Additionally, expandComment: true caused Zabbix to pre-expand macros in trigger.comments with that same current lastvalue before the plugin could substitute per-problem historical values.
- Fix: Added enrichProblemsWithItemHistory which fetches history.get for the problem time window and replaces each item's lastvalue with the closest record at or before each problem's timestamp. Removed expandComment: true from getTriggersByIds so trigger.comments is received as a raw template, then expanded locally via expandItemMacros using historical values for {ITEM.VALUE} and current lastvalue for {ITEM.LASTVALUE}. Host macros ({HOST.NAME}, {HOST.HOST}) are also expanded inline.

## Changes

- [zabbix.ts](vscode-webview://057i4b1ulq1l2tuhq8ckltn183ntgj97qupb2ru0olovjs31o4gv/src/datasource/zabbix/zabbix.ts) — enrichProblemsWithItemHistory private method; expands item and host macros in description and comments; called after joinTriggersWithProblems and joinTriggersWithEvents in getProblems/getProblemsHistory
- [problemsHandler.ts](vscode-webview://057i4b1ulq1l2tuhq8ckltn183ntgj97qupb2ru0olovjs31o4gv/src/datasource/problemsHandler.ts) — expandItemMacros exported function; handles {ITEM.VALUE}, {ITEM.LASTVALUE}, and indexed variants {ITEMn.VALUE} / {ITEMn.LASTVALUE}
- [zabbixAPIConnector.ts](vscode-webview://057i4b1ulq1l2tuhq8ckltn183ntgj97qupb2ru0olovjs31o4gv/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts) — removed expandComment: true from getTriggersByIds; added value_type to selectItems in getTriggersByIds and getTriggers (required by history.get to route requests to the correct per-type history table)
- [types.ts](vscode-webview://057i4b1ulq1l2tuhq8ckltn183ntgj97qupb2ru0olovjs31o4gv/src/datasource/types.ts) — added value_type?: string to ZBXItem
- [problemsHandler.test.ts](vscode-webview://057i4b1ulq1l2tuhq8ckltn183ntgj97qupb2ru0olovjs31o4gv/src/datasource/problemsHandler.test.ts) — 13 tests for expandItemMacros: historical vs current value selection, indexed macros, both macros in the same string, and edge cases
- [zabbix.test.ts](vscode-webview://057i4b1ulq1l2tuhq8ckltn183ntgj97qupb2ru0olovjs31o4gv/src/datasource/zabbix/zabbix.test.ts) — 6 tests for enrichProblemsWithItemHistory: correct historical lookup, per-problem isolation, fallback, and early-exit guards

## After changes
<img width="1134" height="263" alt="image" src="https://github.com/user-attachments/assets/c0240f6e-7457-4317-ad0d-61142a10046c" />


## Test plan

- [x]  Trigger with {ITEM.VALUE} / {ITEM.LASTVALUE} in the Description field and Multiple problem events mode — each problem row shows its own historical value, not the current one
- [x]  Operational data column and item badge also show correct per-problem values
- [x]  Trigger with {HOST.NAME} in description still expands correctly
- [x]  Problems panel loads without errors when no history exists for the window
- [x]  yarn test passes