### PR TITLE
Fix operational data and user macro expansion in problems panel.

### DIFF
--- a/.changeset/fix-opdata-user-macros.md
+++ b/.changeset/fix-opdata-user-macros.md
@@ -1,0 +1,5 @@
+---
+'grafana-zabbix': patch
+---
+
+Fix operational data macro expansion and user macro support in problems panel

--- a/src/datasource/problemsHandler.test.ts
+++ b/src/datasource/problemsHandler.test.ts
@@ -95,12 +95,7 @@ describe('expandUserMacros', () => {
   const globalMacro = (macro: string, value: string) => ({ macro, value });
 
   it('replaces a host macro with its value', () => {
-    const result = expandUserMacros(
-      'Contact: {$CONTACT}',
-      [hostMacro('{$CONTACT}', 'Pepe', '10')],
-      [],
-      ['10']
-    );
+    const result = expandUserMacros('Contact: {$CONTACT}', [hostMacro('{$CONTACT}', 'Pepe', '10')], [], ['10']);
     expect(result).toBe('Contact: Pepe');
   });
 
@@ -115,22 +110,12 @@ describe('expandUserMacros', () => {
   });
 
   it('replaces every occurrence of the same macro', () => {
-    const result = expandUserMacros(
-      '{$CONTACT}/{$CONTACT}',
-      [hostMacro('{$CONTACT}', 'Pepe', '10')],
-      [],
-      ['10']
-    );
+    const result = expandUserMacros('{$CONTACT}/{$CONTACT}', [hostMacro('{$CONTACT}', 'Pepe', '10')], [], ['10']);
     expect(result).toBe('Pepe/Pepe');
   });
 
   it('falls back to global macros when no host macro matches', () => {
-    const result = expandUserMacros(
-      'Region: {$REGION}',
-      [],
-      [globalMacro('{$REGION}', 'eu-west')],
-      ['10']
-    );
+    const result = expandUserMacros('Region: {$REGION}', [], [globalMacro('{$REGION}', 'eu-west')], ['10']);
     expect(result).toBe('Region: eu-west');
   });
 
@@ -145,12 +130,7 @@ describe('expandUserMacros', () => {
   });
 
   it('ignores host macros whose hostid is not in the problem hosts', () => {
-    const result = expandUserMacros(
-      '{$CONTACT}',
-      [hostMacro('{$CONTACT}', 'Pepe', '99')],
-      [],
-      ['10']
-    );
+    const result = expandUserMacros('{$CONTACT}', [hostMacro('{$CONTACT}', 'Pepe', '99')], [], ['10']);
     expect(result).toBe('{$CONTACT}');
   });
 

--- a/src/datasource/problemsHandler.test.ts
+++ b/src/datasource/problemsHandler.test.ts
@@ -1,4 +1,4 @@
-import { expandItemMacros } from './problemsHandler';
+import { expandItemMacros, expandUserMacros, hasUserMacro } from './problemsHandler';
 
 describe('expandItemMacros', () => {
   const item = (historicalValue?: string, originalLastvalue?: string) => ({ historicalValue, originalLastvalue });
@@ -64,5 +64,116 @@ describe('expandItemMacros', () => {
     it('handles undefined text', () => {
       expect(expandItemMacros(undefined as any, [item('12', '7')])).toBeUndefined();
     });
+  });
+});
+
+describe('hasUserMacro', () => {
+  it('returns true when text contains a {$MACRO}', () => {
+    expect(hasUserMacro('Contact: {$CONTACT}')).toBe(true);
+  });
+
+  it('returns true for macros with digits, underscores, and dots', () => {
+    expect(hasUserMacro('{$DB.HOST_1}')).toBe(true);
+  });
+
+  it('returns false when no macro is present', () => {
+    expect(hasUserMacro('plain text')).toBe(false);
+  });
+
+  it('returns false for empty or undefined text', () => {
+    expect(hasUserMacro('')).toBe(false);
+    expect(hasUserMacro(undefined as any)).toBe(false);
+  });
+
+  it('returns false for {ITEM.VALUE}-style macros', () => {
+    expect(hasUserMacro('{ITEM.VALUE} / {HOST.NAME}')).toBe(false);
+  });
+});
+
+describe('expandUserMacros', () => {
+  const hostMacro = (macro: string, value: string, hostid: string) => ({ macro, value, hostid });
+  const globalMacro = (macro: string, value: string) => ({ macro, value });
+
+  it('replaces a host macro with its value', () => {
+    const result = expandUserMacros(
+      'Contact: {$CONTACT}',
+      [hostMacro('{$CONTACT}', 'Pepe', '10')],
+      [],
+      ['10']
+    );
+    expect(result).toBe('Contact: Pepe');
+  });
+
+  it('replaces multiple distinct macros in the same string', () => {
+    const result = expandUserMacros(
+      'CONTACT: {$CONTACT} VERSION: {$VERSION}',
+      [hostMacro('{$CONTACT}', 'Pepe', '10'), hostMacro('{$VERSION}', '6.4.1', '10')],
+      [],
+      ['10']
+    );
+    expect(result).toBe('CONTACT: Pepe VERSION: 6.4.1');
+  });
+
+  it('replaces every occurrence of the same macro', () => {
+    const result = expandUserMacros(
+      '{$CONTACT}/{$CONTACT}',
+      [hostMacro('{$CONTACT}', 'Pepe', '10')],
+      [],
+      ['10']
+    );
+    expect(result).toBe('Pepe/Pepe');
+  });
+
+  it('falls back to global macros when no host macro matches', () => {
+    const result = expandUserMacros(
+      'Region: {$REGION}',
+      [],
+      [globalMacro('{$REGION}', 'eu-west')],
+      ['10']
+    );
+    expect(result).toBe('Region: eu-west');
+  });
+
+  it('prefers host macro over global macro of the same name', () => {
+    const result = expandUserMacros(
+      '{$ENV}',
+      [hostMacro('{$ENV}', 'prod', '10')],
+      [globalMacro('{$ENV}', 'global')],
+      ['10']
+    );
+    expect(result).toBe('prod');
+  });
+
+  it('ignores host macros whose hostid is not in the problem hosts', () => {
+    const result = expandUserMacros(
+      '{$CONTACT}',
+      [hostMacro('{$CONTACT}', 'Pepe', '99')],
+      [],
+      ['10']
+    );
+    expect(result).toBe('{$CONTACT}');
+  });
+
+  it('leaves the raw macro unchanged when no definition is found', () => {
+    expect(expandUserMacros('{$UNKNOWN}', [], [], ['10'])).toBe('{$UNKNOWN}');
+  });
+
+  it('leaves the raw macro unchanged when the macro value is null (secret)', () => {
+    const result = expandUserMacros(
+      '{$SECRET}',
+      [{ macro: '{$SECRET}', value: null as any, hostid: '10' }],
+      [],
+      ['10']
+    );
+    expect(result).toBe('{$SECRET}');
+  });
+
+  it('returns the text unchanged when it contains no macros', () => {
+    expect(expandUserMacros('no macros here', [], [], [])).toBe('no macros here');
+  });
+
+  it('returns empty/undefined text unchanged', () => {
+    expect(expandUserMacros('', [], [], [])).toBe('');
+    expect(expandUserMacros(undefined as any, [], [], [])).toBeUndefined();
   });
 });

--- a/src/datasource/problemsHandler.ts
+++ b/src/datasource/problemsHandler.ts
@@ -249,6 +249,45 @@ export function expandItemMacros(text: string, items: ItemResolution[]): string 
   return result;
 }
 
+export interface UserMacro {
+  macro: string;
+  value?: string;
+  hostid?: string;
+}
+
+const USER_MACRO_PATTERN = /\{\$[A-Z0-9_.]+\}/g;
+
+export function hasUserMacro(text: string): boolean {
+  if (!text) {
+    return false;
+  }
+  return /\{\$[A-Z0-9_.]+\}/.test(text);
+}
+
+export function expandUserMacros(
+  text: string,
+  hostMacros: UserMacro[],
+  globalMacros: UserMacro[],
+  hostids: string[]
+): string {
+  if (!text) {
+    return text;
+  }
+  return text.replace(USER_MACRO_PATTERN, (macroName) => {
+    const hostMacro = hostMacros.find(
+      (m) => m.macro === macroName && m.hostid !== undefined && hostids.includes(m.hostid)
+    );
+    if (hostMacro && hostMacro.value != null) {
+      return hostMacro.value;
+    }
+    const globalMacro = globalMacros.find((m) => m.macro === macroName);
+    if (globalMacro && globalMacro.value != null) {
+      return globalMacro.value;
+    }
+    return macroName;
+  });
+}
+
 const problemsHandler = {
   addTriggerDataSource,
   addTriggerHostProxy,

--- a/src/datasource/zabbix/zabbix.test.ts
+++ b/src/datasource/zabbix/zabbix.test.ts
@@ -3,6 +3,7 @@ import responseHandler, { handleMultiSLIResponse, handleServiceResponse, handleS
 import { Zabbix } from './zabbix';
 
 jest.mock('../problemsHandler', () => ({
+  ...jest.requireActual('../problemsHandler'),
   joinTriggersWithEvents: jest.fn(),
   joinTriggersWithProblems: jest.fn(),
 }));
@@ -302,6 +303,42 @@ describe('Zabbix', () => {
       expect(result[0].items[0].lastvalue).toBe('fallback');
     });
 
+    it('expands {ITEM.VALUE} in description and comments using historical value, not latest lastvalue', async () => {
+      const problems: any[] = [
+        makeProblem(1000, {
+          description: 'Value: {ITEM.VALUE}, Last: {ITEM.LASTVALUE}',
+          comments: 'Value received: {ITEM.VALUE} / Last value received: {ITEM.LASTVALUE}',
+          items: [makeItem({ lastvalue: '99' })],
+        }),
+      ];
+      zabbix.zabbixAPI.getHistory = jest.fn().mockResolvedValue([
+        { itemid: '601', clock: '995', value: '12' },
+        { itemid: '601', clock: '1010', value: '50' },
+      ]);
+
+      const result = await (zabbix as any).enrichProblemsWithItemHistory(problems);
+
+      expect(result[0].description).toBe('Value: 12, Last: 99');
+      expect(result[0].comments).toBe('Value received: 12 / Last value received: 99');
+    });
+
+    it('expands {ITEM.VALUE} in opdata using historical value', async () => {
+      const problems: any[] = [
+        makeProblem(1000, {
+          opdata: 'Value: {ITEM.VALUE}',
+          items: [makeItem({ lastvalue: '99' })],
+        }),
+      ];
+      zabbix.zabbixAPI.getHistory = jest.fn().mockResolvedValue([
+        { itemid: '601', clock: '995', value: '12' },
+        { itemid: '601', clock: '1010', value: '50' },
+      ]);
+
+      const result = await (zabbix as any).enrichProblemsWithItemHistory(problems);
+
+      expect(result[0].opdata).toBe('Value: 12');
+    });
+
     it('skips history fetch when no items have value_type', async () => {
       const problems: any[] = [
         makeProblem(1000, { items: [{ itemid: '601', name: 'i', key_: 'k', lastvalue: 'current' }] }),
@@ -338,6 +375,67 @@ describe('Zabbix', () => {
       // A hard row cap must be sent to history.get.
       expect(typeof limit).toBe('number');
       expect(limit).toBeGreaterThan(0);
+    });
+
+    it('expands user-defined host macros in description and comments', async () => {
+      const problems: any[] = [
+        makeProblem(1000, {
+          description: 'CONTACT: {$CONTACT}',
+          comments: 'VERSION: {$VERSION}',
+          hosts: [{ hostid: '10', name: 'host01', host: 'host01' }],
+          items: [],
+        }),
+      ];
+      zabbix.zabbixAPI.getHistory = jest.fn();
+      zabbix.zabbixAPI.getMacros = jest.fn().mockResolvedValue([
+        { macro: '{$CONTACT}', value: 'Pepe', hostid: '10' },
+        { macro: '{$VERSION}', value: '6.4.1', hostid: '10' },
+      ]);
+      zabbix.zabbixAPI.getGlobalMacros = jest.fn().mockResolvedValue([]);
+
+      const result = await (zabbix as any).enrichProblemsWithItemHistory(problems);
+
+      expect(result[0].description).toBe('CONTACT: Pepe');
+      expect(result[0].comments).toBe('VERSION: 6.4.1');
+      expect(zabbix.zabbixAPI.getMacros).toHaveBeenCalledWith(['10']);
+      expect(zabbix.zabbixAPI.getGlobalMacros).toHaveBeenCalled();
+      expect(zabbix.zabbixAPI.getHistory).not.toHaveBeenCalled();
+    });
+
+    it('does not fetch macros when no user macros are present in text', async () => {
+      const problems: any[] = [
+        makeProblem(1000, {
+          description: 'plain description',
+          comments: 'plain comments',
+          hosts: [{ hostid: '10' }],
+        }),
+      ];
+      zabbix.zabbixAPI.getHistory = jest.fn().mockResolvedValue([]);
+      zabbix.zabbixAPI.getMacros = jest.fn();
+      zabbix.zabbixAPI.getGlobalMacros = jest.fn();
+
+      await (zabbix as any).enrichProblemsWithItemHistory(problems);
+
+      expect(zabbix.zabbixAPI.getMacros).not.toHaveBeenCalled();
+      expect(zabbix.zabbixAPI.getGlobalMacros).not.toHaveBeenCalled();
+    });
+
+    it('falls back to global macros when host macro is not defined', async () => {
+      const problems: any[] = [
+        makeProblem(1000, {
+          description: 'Region: {$REGION}',
+          comments: '',
+          hosts: [{ hostid: '10' }],
+          items: [],
+        }),
+      ];
+      zabbix.zabbixAPI.getHistory = jest.fn();
+      zabbix.zabbixAPI.getMacros = jest.fn().mockResolvedValue([]);
+      zabbix.zabbixAPI.getGlobalMacros = jest.fn().mockResolvedValue([{ macro: '{$REGION}', value: 'eu-west' }]);
+
+      const result = await (zabbix as any).enrichProblemsWithItemHistory(problems);
+
+      expect(result[0].description).toBe('Region: eu-west');
     });
   });
 

--- a/src/datasource/zabbix/zabbix.ts
+++ b/src/datasource/zabbix/zabbix.ts
@@ -4,7 +4,13 @@ import _ from 'lodash';
 // eslint-disable-next-line
 import moment from 'moment';
 import semver from 'semver';
-import { expandItemMacros, joinTriggersWithEvents, joinTriggersWithProblems } from '../problemsHandler';
+import {
+  expandItemMacros,
+  expandUserMacros,
+  hasUserMacro,
+  joinTriggersWithEvents,
+  joinTriggersWithProblems,
+} from '../problemsHandler';
 import responseHandler, { handleMultiSLIResponse, handleServiceResponse, handleSLIResponse } from '../responseHandler';
 import { ProblemDTO, ZBXApp, ZBXHost, ZBXItem, ZBXItemTag, ZBXTrigger } from '../types';
 import { ZabbixDSOptions } from '../types/config';
@@ -502,7 +508,12 @@ export class Zabbix implements ZabbixConnector {
       'itemid'
     );
     const itemsWithType = allItems.filter((item) => item.value_type !== undefined);
-    if (!itemsWithType.length) {
+
+    const needsUserMacros = problems.some(
+      (p) => hasUserMacro(p.description) || hasUserMacro(p.comments) || hasUserMacro(p.opdata)
+    );
+
+    if (!itemsWithType.length && !needsUserMacros) {
       return problems;
     }
 
@@ -517,7 +528,18 @@ export class Zabbix implements ZabbixConnector {
     const timeFrom = Math.max(minTimestamp - HISTORY_LOOKBACK_SECONDS, maxTimestamp - MAX_HISTORY_WINDOW_SECONDS);
     const timeTill = maxTimestamp + 60;
 
-    const history = await this.zabbixAPI.getHistory(itemsWithType, timeFrom, timeTill, HISTORY_FETCH_LIMIT);
+    const macroHostids = needsUserMacros
+      ? _.uniq(problems.flatMap((p) => (p.hosts || []).map((h: ZBXHost) => h.hostid)).filter(Boolean))
+      : [];
+
+    const [history, hostMacros, globalMacros] = await Promise.all([
+      itemsWithType.length
+        ? this.zabbixAPI.getHistory(itemsWithType, timeFrom, timeTill, HISTORY_FETCH_LIMIT)
+        : Promise.resolve([]),
+      macroHostids.length ? this.zabbixAPI.getMacros(macroHostids) : Promise.resolve([]),
+      needsUserMacros ? this.zabbixAPI.getGlobalMacros() : Promise.resolve([]),
+    ]);
+
     const historyByItem = _.groupBy(history, 'itemid');
 
     return problems.map((problem) => {
@@ -531,6 +553,8 @@ export class Zabbix implements ZabbixConnector {
         };
       });
 
+      const problemHostids = (problem.hosts || []).map((h: ZBXHost) => h.hostid).filter(Boolean);
+
       const expandMacros = (text: string): string => {
         if (!text) {
           return text;
@@ -541,13 +565,16 @@ export class Zabbix implements ZabbixConnector {
           result = result.replace(/\{HOST\.NAME\}/g, host.name || '');
           result = result.replace(/\{HOST\.HOST\}/g, host.host || '');
         }
-        return expandItemMacros(result, itemResolutions);
+        result = expandItemMacros(result, itemResolutions);
+        result = expandUserMacros(result, hostMacros, globalMacros, problemHostids);
+        return result;
       };
 
       return {
         ...problem,
         description: expandMacros(problem.description),
         comments: expandMacros(problem.comments),
+        opdata: expandMacros(problem.opdata),
         items: itemResolutions.map((r) => r.updatedItem),
       };
     });


### PR DESCRIPTION
Expand {ITEM.VALUE} in opdata using historical item values at problem creation time, and resolve user-defined {$MACRO} placeholders in problem description, comments, and operational data.

Fixes #1832
