### PR TITLE
ProblemsPanel: Fix acknowledges list not scrolling with long messages

### DIFF
--- a/.changeset/tame-bats-share.md
+++ b/.changeset/tame-bats-share.md
@@ -1,0 +1,5 @@
+---
+'grafana-zabbix': patch
+---
+
+ProblemsPanel: Fix acknowledges list not scrolling when messages are long. Long acknowledgement messages now wrap instead of overflowing horizontally, so the acknowledges container scrolls vertically as expected.

--- a/src/styles/_panel-problems.scss
+++ b/src/styles/_panel-problems.scss
@@ -237,13 +237,22 @@
 
       .problem-ack-list {
         display: flex;
-        overflow: auto;
         white-space: pre-line;
 
         .problem-ack-col {
           display: flex;
           flex-direction: column;
           padding-right: 0.8rem;
+          // Allow the columns to shrink so long messages wrap instead of
+          // overflowing horizontally (which hid the scrollbar and made the
+          // acknowledges list appear unscrollable).
+          min-width: 0;
+        }
+
+        .problem-ack-message {
+          // Break very long messages that contain no spaces so they wrap
+          // within the column; the container then scrolls vertically.
+          overflow-wrap: anywhere;
         }
 
         .problem-ack-time,


### PR DESCRIPTION
## Problem

Customer reported that the **Acknowledges** list in the problem details does not scroll when there are several acknowledgements with long messages (e.g. long messages with no spaces).

## Root cause

In `_panel-problems.scss`:

- `.problem-ack-list` had its own `overflow: auto`, making it a **nested scroll container** inside `.problem-ack-container` (which is the element that's meant to scroll vertically via `max-height: 8rem; overflow: auto`).
- Acknowledgement messages with no spaces never wrapped, so the list overflowed **horizontally**.
- That horizontal scrollbar sat at the bottom of the full-height inner list, **hidden below the clipped container**, so it was unreachable — and a wheel/trackpad gesture over the list scrolled it sideways instead of scrolling the container down. The list appeared unscrollable and the messages were unreadable.

## Fix

- Remove the inner list's `overflow` (no more nested scroll container).
- Allow the columns to shrink (`min-width: 0`).
- Wrap long messages (`overflow-wrap: anywhere`).

The acknowledges container now scrolls vertically as expected and long messages wrap and stay readable.

## Before / After

| Before | After |
|---|---|
| <img width="955" height="113" alt="before" src="https://github.com/user-attachments/assets/f16c9ba6-7cf9-42c2-bb70-ff7bef59c12d" /> | <img width="955" height="113" alt="after" src="https://github.com/user-attachments/assets/00626567-c825-4d48-9032-ab55aebb9f84" /> |
