### PR TITLE
fix(problems-panel): make historical item value lookup opt-in and bounded

### DIFF
--- a/.changeset/fix-problems-history-overload.md
+++ b/.changeset/fix-problems-history-overload.md
@@ -1,0 +1,5 @@
+---
+'grafana-zabbix': patch
+---
+
+ProblemsPanel: Fix severe Zabbix DB / PHP-FPM overload caused by the per-problem historical item value lookup (#2427). The `history.get` enrichment introduced in 6.3.1 now runs only when explicitly enabled via the new "Item value at problem time" query option (off by default, restoring 6.3.0 behaviour). When enabled, the history window span and result size are bounded to protect the Zabbix frontend and database in large environments.

--- a/docs/sources/query-editor.md
+++ b/docs/sources/query-editor.md
@@ -164,6 +164,7 @@ Expand the **Options** section to access additional settings:
 | **Use time range** | Restrict results to the dashboard time range. |
 | **Hosts in maintenance** | Include hosts that are currently in maintenance. |
 | **Host proxy** | Include proxy information in the results. |
+| **Item value at problem time** | Resolve each problem's item value at its creation time (used by `{ITEM.VALUE}` and operational data) via a `history.get` lookup. Disabled by default — it adds load and can impact performance in large environments with many active problems. Leave off unless you need historical-value accuracy. |
 | **Limit** | Maximum number of problems to return. Default: `1001`. |
 
 ### User macros

--- a/src/datasource/components/QueryEditor/QueryOptionsEditor.tsx
+++ b/src/datasource/components/QueryEditor/QueryOptionsEditor.tsx
@@ -180,6 +180,19 @@ export const QueryOptionsEditor = ({ queryType, queryOptions, onChange }: Props)
             onChange={() => onChange({ ...queryOptions, hostProxy: !queryOptions.hostProxy })}
           />
         </InlineField>
+        <InlineField
+          label="Item value at problem time"
+          labelWidth={24}
+          tooltip="Resolve each problem's item value at its creation time via history.get (for {ITEM.VALUE} / operational data). May impact performance in large environments with many active problems. Disabled by default."
+        >
+          <InlineSwitch
+            data-testid="zabbix-problems-fetch-historical-value"
+            value={queryOptions.fetchHistoricalItemValue}
+            onChange={() =>
+              onChange({ ...queryOptions, fetchHistoricalItemValue: !queryOptions.fetchHistoricalItemValue })
+            }
+          />
+        </InlineField>
         <InlineField label="Limit" labelWidth={24}>
           <Input width={12} type="number" defaultValue={queryOptions.limit} onBlur={onLimitChange} />
         </InlineField>

--- a/src/datasource/datasource.ts
+++ b/src/datasource/datasource.ts
@@ -610,6 +610,8 @@ export class ZabbixDatasource extends DataSourceWithBackend<ZabbixMetricsQuery, 
       problemsOptions.severities = severities;
     }
 
+    problemsOptions.fetchHistoricalItemValue = !!target.options?.fetchHistoricalItemValue;
+
     let getProblemsPromise: Promise<ProblemDTO[]>;
     if (showProblems === ShowProblemTypes.History || target.options?.useTimeRange) {
       problemsOptions.timeFrom = timeFrom;

--- a/src/datasource/types/query.ts
+++ b/src/datasource/types/query.ts
@@ -62,6 +62,9 @@ export interface ZabbixQueryOptions {
   useTimeRange?: boolean;
   severities?: number[];
   count?: boolean;
+  // When enabled, fetch each problem's item value at its creation time via
+  // history.get. Off by default — it is costly in large environments (issue #2427).
+  fetchHistoricalItemValue?: boolean;
 
   // Annotations
   showOkEvents?: boolean;

--- a/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
+++ b/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
@@ -297,7 +297,7 @@ export class ZabbixAPIConnector {
    * @param  {Number} timeTill   Time in seconds
    * @return {Array}  Array of Zabbix history objects
    */
-  getHistory(items, timeFrom, timeTill) {
+  getHistory(items, timeFrom, timeTill, limit?) {
     // Group items by value type and perform request for each value type
     const grouped_items = _.groupBy(items, 'value_type');
     const promises = _.map(grouped_items, (items, value_type) => {
@@ -314,6 +314,12 @@ export class ZabbixAPIConnector {
       // Relative queries (e.g. last hour) don't include an end time
       if (timeTill) {
         params.time_till = timeTill;
+      }
+
+      // Optional hard cap on rows returned, to protect the Zabbix frontend/DB
+      // from unbounded result sets (issue #2427).
+      if (limit) {
+        params.limit = limit;
       }
 
       return this.request('history.get', params);

--- a/src/datasource/zabbix/zabbix.test.ts
+++ b/src/datasource/zabbix/zabbix.test.ts
@@ -208,6 +208,26 @@ describe('Zabbix', () => {
 
       expect(zabbix.zabbixAPI.getEventsHistory).toHaveBeenCalledWith(['21'], ['31'], undefined, {});
     });
+
+    it('does not fetch item history by default (fetchHistoricalItemValue off)', async () => {
+      (joinTriggersWithEvents as jest.Mock).mockReturnValue([
+        { triggerid: '501', timestamp: 1000, items: [{ itemid: '601', value_type: '0', lastvalue: 'x' }] },
+      ]);
+
+      await zabbix.getProblemsHistory('group.*', 'host.*', 'app.*', undefined, {});
+
+      expect(zabbix.zabbixAPI.getHistory).not.toHaveBeenCalled();
+    });
+
+    it('fetches item history only when fetchHistoricalItemValue is enabled', async () => {
+      (joinTriggersWithEvents as jest.Mock).mockReturnValue([
+        { triggerid: '501', timestamp: 1000, items: [{ itemid: '601', value_type: '0', lastvalue: 'x' }] },
+      ]);
+
+      await zabbix.getProblemsHistory('group.*', 'host.*', 'app.*', undefined, { fetchHistoricalItemValue: true });
+
+      expect(zabbix.zabbixAPI.getHistory).toHaveBeenCalled();
+    });
   });
 
   describe('enrichProblemsWithItemHistory', () => {
@@ -301,6 +321,23 @@ describe('Zabbix', () => {
 
       expect(result).toEqual([]);
       expect(zabbix.zabbixAPI.getHistory).not.toHaveBeenCalled();
+    });
+
+    it('bounds the history window span and passes a row limit even for long-open problems', async () => {
+      const recent = 1_000_000;
+      const sixtyDays = 60 * 86400;
+      const problems: any[] = [makeProblem(recent - sixtyDays), makeProblem(recent)];
+      const getHistory = jest.fn().mockResolvedValue([]);
+      zabbix.zabbixAPI.getHistory = getHistory;
+
+      await (zabbix as any).enrichProblemsWithItemHistory(problems);
+
+      const [, timeFrom, timeTill, limit] = getHistory.mock.calls[0];
+      // The 60-day problem span must NOT translate into a 60-day history query.
+      expect(timeTill - timeFrom).toBeLessThan(2 * 86400);
+      // A hard row cap must be sent to history.get.
+      expect(typeof limit).toBe('number');
+      expect(limit).toBeGreaterThan(0);
     });
   });
 

--- a/src/datasource/zabbix/zabbix.ts
+++ b/src/datasource/zabbix/zabbix.ts
@@ -17,6 +17,13 @@ import { ZabbixAPIConnector } from './connectors/zabbix_api/zabbixAPIConnector';
 import { CachingProxy } from './proxy/cachingProxy';
 import { Host, ZabbixConnector } from './types';
 
+// Bounds for the optional "historical item value at problem creation time" lookup
+// (issue #2427). These keep the single batched history.get from scanning an
+// unbounded time range / returning an unbounded number of rows.
+const HISTORY_LOOKBACK_SECONDS = 3600; // per-problem lookback (covers typical polling intervals)
+const MAX_HISTORY_WINDOW_SECONDS = 4 * 3600; // cap the total span regardless of oldest open problem
+const HISTORY_FETCH_LIMIT = 50000; // hard cap on rows returned by history.get
+
 interface AppsResponse extends Array<any> {
   appFilterEmpty?: boolean;
   hostids?: any[];
@@ -500,11 +507,17 @@ export class Zabbix implements ZabbixConnector {
     }
 
     const timestamps = problems.map((p) => p.timestamp);
-    // Use a 1-hour lookback to cover typical Zabbix polling intervals (up to 5 min)
-    const timeFrom = Math.min(...timestamps) - 3600;
-    const timeTill = Math.max(...timestamps) + 60;
+    const minTimestamp = Math.min(...timestamps);
+    const maxTimestamp = Math.max(...timestamps);
+    // Use a 1-hour lookback to cover typical Zabbix polling intervals (up to 5 min).
+    // Cap the overall span so that a single long-open problem cannot widen the
+    // history.get window (and the resulting row count) without bound — which would
+    // overload the Zabbix frontend/DB in large environments (see issue #2427).
+    // Problems older than the cap fall back to their current lastvalue.
+    const timeFrom = Math.max(minTimestamp - HISTORY_LOOKBACK_SECONDS, maxTimestamp - MAX_HISTORY_WINDOW_SECONDS);
+    const timeTill = maxTimestamp + 60;
 
-    const history = await this.zabbixAPI.getHistory(itemsWithType, timeFrom, timeTill);
+    const history = await this.zabbixAPI.getHistory(itemsWithType, timeFrom, timeTill, HISTORY_FETCH_LIMIT);
     const historyByItem = _.groupBy(history, 'itemid');
 
     return problems.map((problem) => {
@@ -578,7 +591,7 @@ export class Zabbix implements ZabbixConnector {
         return Promise.all([Promise.resolve(problems), this.zabbixAPI.getTriggersByIds(triggerids)]);
       })
       .then(([problems, triggers]) => joinTriggersWithProblems(problems, triggers))
-      .then((problems) => this.enrichProblemsWithItemHistory(problems))
+      .then((problems) => (options?.fetchHistoricalItemValue ? this.enrichProblemsWithItemHistory(problems) : problems))
       .then((triggers) => this.filterTriggersByProxy(triggers, proxyFilter));
     // .then(triggers => this.expandUserMacro.bind(this)(triggers, true));
   }
@@ -615,7 +628,7 @@ export class Zabbix implements ZabbixConnector {
         return Promise.all([Promise.resolve(problems), this.zabbixAPI.getTriggersByIds(triggerids)]);
       })
       .then(([problems, triggers]) => joinTriggersWithEvents(problems, triggers, { valueFromEvent }))
-      .then((problems) => this.enrichProblemsWithItemHistory(problems))
+      .then((problems) => (options?.fetchHistoricalItemValue ? this.enrichProblemsWithItemHistory(problems) : problems))
       .then((triggers) => this.filterTriggersByProxy(triggers, proxyFilter));
     // .then(triggers => this.expandUserMacro.bind(this)(triggers, true));
   }


### PR DESCRIPTION
Fixes #2427.

## Problem

`enrichProblemsWithItemHistory` (added in 6.3.1, #2402) runs on **every** Problems-panel render and issues a **single, unbounded** `history.get`:
- `output: "extend"`, **no `limit`**
- time window = `min(open-problem clock) − 1h → max + 60s`

The window is driven by the *oldest still-open problem*, so with long-open problems it stretches to **weeks** across all problem items, returning a massive result set. At scale this overloads the Zabbix DB (wide `history_uint` scans + large external-merge sorts) and exhausts PHP-FPM memory (`db.inc.php` / `CJsonRpc.php`) → HTTP 500 and an unresponsive Zabbix UI.

> The issue describes this as an "N+1 per problem" pattern. It's actually a *single batched* but *unbounded* call whose window is dictated by the oldest open problem — confirmed by reproducing it locally.

## Fix

1. **Opt-in** — new *"Item value at problem time"* Problems query option, **off by default**. When off, the enrichment (and its `history.get`) is skipped entirely → 6.3.0 behaviour, zero cost by default.
2. **Bounded when enabled** — cap the window span (`MAX_HISTORY_WINDOW_SECONDS = 4h`) so one ancient problem can't widen it (older problems fall back to `lastvalue`), and pass a hard row cap (`HISTORY_FETCH_LIMIT = 50000`) through to `history.get`.

## Tests

Unit tests (`zabbix.test.ts`): enrichment is skipped unless the option is set; the window span is bounded and a row limit is sent even for long-open problems. The new option is documented in `query-editor.md`.

The **end-to-end test** that exercises this against a real Zabbix backend lives in the e2e-environment PR (#2458), which is stacked on this one (the e2e test needs this fix to pass).