### PR TITLE
Support item tag values as alias tokens

### DIFF
--- a/docs/sources/functions.md
+++ b/docs/sources/functions.md
@@ -331,7 +331,7 @@ Alias functions change the display names of time series. The following template 
 | `$__zbx_host_name` | Visible name of the host. |
 | `$__zbx_host` | Technical name of the host. |
 | `$__zbx_host_id` | ID of the host. |
-| `$__zbx_item_tag_<name>` | Value of the item tag with the given name. Tag names are sanitized to alphanumeric characters and underscores (for example, `App Name` becomes `$__zbx_item_tag_App_Name`). A tag that exists but has no value resolves to an empty string; a tag that is not present on the item is left unresolved (the literal token remains in the output). When multiple values exist for the same tag name, they are joined with `, `. Requires Zabbix 5.4 or later. |
+| `$__zbx_item_tag_<name>` | Value of the item tag with the given name. Tag names are sanitized to alphanumeric characters and underscores (for example, `App Name` becomes `$__zbx_item_tag_App_Name`, and `!!!` becomes `$__zbx_item_tag___`). Empty tag names are skipped. A tag that exists but has no value resolves to an empty string; a tag that is not present on the item is left unresolved (the literal token remains in the output). When multiple values exist for the same tag name, they are joined with `, `. Requires Zabbix 5.4 or later. |
 
 ```
 setAlias($__zbx_host_name: $__zbx_item)       -- backend01: CPU user time

--- a/docs/sources/functions.md
+++ b/docs/sources/functions.md
@@ -331,10 +331,12 @@ Alias functions change the display names of time series. The following template 
 | `$__zbx_host_name` | Visible name of the host. |
 | `$__zbx_host` | Technical name of the host. |
 | `$__zbx_host_id` | ID of the host. |
+| `$__zbx_item_tag_<name>` | Value of the item tag with the given name. Tag names are sanitized to alphanumeric characters and underscores (for example, `App Name` becomes `$__zbx_item_tag_App_Name`). A tag that exists but has no value resolves to an empty string; a tag that is not present on the item is left unresolved (the literal token remains in the output). When multiple values exist for the same tag name, they are joined with `, `. Requires Zabbix 5.4 or later. |
 
 ```
 setAlias($__zbx_host_name: $__zbx_item)       -- backend01: CPU user time
 setAlias(Item key: $__zbx_item_key)            -- Item key: system.cpu.load[percpu,avg1]
+setAlias($__zbx_item_tag_service)              -- checkout (from item tag "service: checkout")
 ```
 
 ### setAlias

--- a/pkg/datasource/response_handler.go
+++ b/pkg/datasource/response_handler.go
@@ -102,7 +102,7 @@ func seriesToDataFrame(series *timeseries.TimeSeriesData, valuemaps []zabbix.Val
 		valueField.Labels["host"] = item.Hosts[0].Name
 	}
 
-	addItemTagScopedVars(scopedVars, valueField.Labels, item.Tags)
+	addItemTagScopedVars(scopedVars, item.Tags)
 
 	valueField.Config = &data.FieldConfig{
 		DisplayNameFromDS: seriesName,
@@ -193,7 +193,7 @@ func sanitizeTagName(name string) string {
 	return tagNameSanitizePattern.ReplaceAllString(name, "_")
 }
 
-func addItemTagScopedVars(scopedVars map[string]ScopedVar, labels data.Labels, tags []zabbix.Tag) {
+func addItemTagScopedVars(scopedVars map[string]ScopedVar, tags []zabbix.Tag) {
 	if len(tags) == 0 {
 		return
 	}
@@ -210,10 +210,7 @@ func addItemTagScopedVars(scopedVars map[string]ScopedVar, labels data.Labels, t
 
 	for key, values := range tagValues {
 		sort.Strings(values)
-		joined := strings.Join(values, ", ")
-		scopedVars[key] = ScopedVar{Value: joined}
-		labelKey := strings.TrimPrefix(key, "__zbx_item_tag_")
-		labels["item_tag_"+labelKey] = joined
+		scopedVars[key] = ScopedVar{Value: strings.Join(values, ", ")}
 	}
 }
 

--- a/pkg/datasource/response_handler.go
+++ b/pkg/datasource/response_handler.go
@@ -3,7 +3,9 @@ package datasource
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/alexanderzobnin/grafana-zabbix/pkg/gtime"
@@ -100,6 +102,8 @@ func seriesToDataFrame(series *timeseries.TimeSeriesData, valuemaps []zabbix.Val
 		valueField.Labels["host"] = item.Hosts[0].Name
 	}
 
+	addItemTagScopedVars(scopedVars, valueField.Labels, item.Tags)
+
 	valueField.Config = &data.FieldConfig{
 		DisplayNameFromDS: seriesName,
 		Custom: map[string]interface{}{
@@ -180,7 +184,38 @@ func getTrendPointValue(point zabbix.TrendPoint, valueType string) (float64, err
 	return 0, backend.DownstreamError(fmt.Errorf("failed to get trend value, unknown value type: %s", valueType))
 }
 
-var fixedUpdateIntervalPattern = regexp.MustCompile(`^(\d+)([smhdw]?)$`)
+var (
+	fixedUpdateIntervalPattern = regexp.MustCompile(`^(\d+)([smhdw]?)$`)
+	tagNameSanitizePattern     = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+)
+
+func sanitizeTagName(name string) string {
+	return tagNameSanitizePattern.ReplaceAllString(name, "_")
+}
+
+func addItemTagScopedVars(scopedVars map[string]ScopedVar, labels data.Labels, tags []zabbix.Tag) {
+	if len(tags) == 0 {
+		return
+	}
+
+	tagValues := make(map[string][]string)
+	for _, tag := range tags {
+		sanitized := sanitizeTagName(tag.Tag)
+		if sanitized == "" {
+			continue
+		}
+		key := "__zbx_item_tag_" + sanitized
+		tagValues[key] = append(tagValues[key], tag.Value)
+	}
+
+	for key, values := range tagValues {
+		sort.Strings(values)
+		joined := strings.Join(values, ", ")
+		scopedVars[key] = ScopedVar{Value: joined}
+		labelKey := strings.TrimPrefix(key, "__zbx_item_tag_")
+		labels["item_tag_"+labelKey] = joined
+	}
+}
 
 func parseItemUpdateInterval(delay string) *time.Duration {
 	if valid := fixedUpdateIntervalPattern.MatchString(delay); !valid {

--- a/pkg/datasource/response_handler_test.go
+++ b/pkg/datasource/response_handler_test.go
@@ -1,0 +1,80 @@
+package datasource
+
+import (
+	"testing"
+
+	"github.com/alexanderzobnin/grafana-zabbix/pkg/timeseries"
+	"github.com/alexanderzobnin/grafana-zabbix/pkg/zabbix"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeTagName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "simple name", input: "service", expected: "service"},
+		{name: "spaces", input: "App Name", expected: "App_Name"},
+		{name: "dots and dashes", input: "App.Name-test", expected: "App_Name_test"},
+		{name: "empty string", input: "", expected: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, sanitizeTagName(tt.input))
+		})
+	}
+}
+
+func TestAddItemTagScopedVars(t *testing.T) {
+	scopedVars := map[string]ScopedVar{}
+	labels := data.Labels{}
+
+	addItemTagScopedVars(scopedVars, labels, []zabbix.Tag{
+		{Tag: "service", Value: "payment"},
+		{Tag: "App Name", Value: "api"},
+		{Tag: "service", Value: "checkout"},
+		{Tag: "monitoring"},
+	})
+
+	assert.Equal(t, ScopedVar{Value: "checkout, payment"}, scopedVars["__zbx_item_tag_service"])
+	assert.Equal(t, ScopedVar{Value: "api"}, scopedVars["__zbx_item_tag_App_Name"])
+	assert.Equal(t, ScopedVar{Value: ""}, scopedVars["__zbx_item_tag_monitoring"])
+	assert.Equal(t, "checkout, payment", labels["item_tag_service"])
+	assert.Equal(t, "api", labels["item_tag_App_Name"])
+	assert.Equal(t, "", labels["item_tag_monitoring"])
+}
+
+func TestSeriesToDataFrameItemTagScopedVars(t *testing.T) {
+	series := &timeseries.TimeSeriesData{
+		Meta: timeseries.TimeSeriesMeta{
+			Name: "CPU load",
+			Item: &zabbix.Item{
+				Name:  "CPU load",
+				Key:   "system.cpu.load",
+				Delay: "1m",
+				Tags: []zabbix.Tag{
+					{Tag: "service", Value: "checkout"},
+					{Tag: "Env", Value: "prod"},
+				},
+			},
+		},
+	}
+
+	frame := seriesToDataFrame(series, nil)
+	require.NotNil(t, frame)
+
+	valueField, fieldIndex := frame.FieldByName(data.TimeSeriesValueFieldName)
+	require.NotEqual(t, -1, fieldIndex)
+	require.NotNil(t, valueField)
+
+	scopedVars := valueField.Config.Custom["scopedVars"].(map[string]ScopedVar)
+
+	assert.Equal(t, ScopedVar{Value: "checkout"}, scopedVars["__zbx_item_tag_service"])
+	assert.Equal(t, ScopedVar{Value: "prod"}, scopedVars["__zbx_item_tag_Env"])
+	assert.Equal(t, "checkout", valueField.Labels["item_tag_service"])
+	assert.Equal(t, "prod", valueField.Labels["item_tag_Env"])
+}

--- a/pkg/datasource/response_handler_test.go
+++ b/pkg/datasource/response_handler_test.go
@@ -19,6 +19,7 @@ func TestSanitizeTagName(t *testing.T) {
 		{name: "simple name", input: "service", expected: "service"},
 		{name: "spaces", input: "App Name", expected: "App_Name"},
 		{name: "dots and dashes", input: "App.Name-test", expected: "App_Name_test"},
+		{name: "all special characters", input: "!!!", expected: "___"},
 		{name: "empty string", input: "", expected: ""},
 	}
 
@@ -31,9 +32,8 @@ func TestSanitizeTagName(t *testing.T) {
 
 func TestAddItemTagScopedVars(t *testing.T) {
 	scopedVars := map[string]ScopedVar{}
-	labels := data.Labels{}
 
-	addItemTagScopedVars(scopedVars, labels, []zabbix.Tag{
+	addItemTagScopedVars(scopedVars, []zabbix.Tag{
 		{Tag: "service", Value: "payment"},
 		{Tag: "App Name", Value: "api"},
 		{Tag: "service", Value: "checkout"},
@@ -43,9 +43,6 @@ func TestAddItemTagScopedVars(t *testing.T) {
 	assert.Equal(t, ScopedVar{Value: "checkout, payment"}, scopedVars["__zbx_item_tag_service"])
 	assert.Equal(t, ScopedVar{Value: "api"}, scopedVars["__zbx_item_tag_App_Name"])
 	assert.Equal(t, ScopedVar{Value: ""}, scopedVars["__zbx_item_tag_monitoring"])
-	assert.Equal(t, "checkout, payment", labels["item_tag_service"])
-	assert.Equal(t, "api", labels["item_tag_App_Name"])
-	assert.Equal(t, "", labels["item_tag_monitoring"])
 }
 
 func TestSeriesToDataFrameItemTagScopedVars(t *testing.T) {
@@ -75,6 +72,4 @@ func TestSeriesToDataFrameItemTagScopedVars(t *testing.T) {
 
 	assert.Equal(t, ScopedVar{Value: "checkout"}, scopedVars["__zbx_item_tag_service"])
 	assert.Equal(t, ScopedVar{Value: "prod"}, scopedVars["__zbx_item_tag_Env"])
-	assert.Equal(t, "checkout", valueField.Labels["item_tag_service"])
-	assert.Equal(t, "prod", valueField.Labels["item_tag_Env"])
 }

--- a/pkg/zabbix/methods.go
+++ b/pkg/zabbix/methods.go
@@ -451,6 +451,11 @@ func (ds *Zabbix) GetItemsByIDs(ctx context.Context, itemids []string) ([]*Item,
 		"selectHosts": []string{"hostid", "name"},
 	}
 
+	// Item tags were introduced in Zabbix 5.4; older versions don't support selectTags.
+	if ds.version >= 54 {
+		params["selectTags"] = "extend"
+	}
+
 	result, err := ds.Request(ctx, &ZabbixAPIRequest{Method: "item.get", Params: params})
 	if err != nil {
 		return nil, err

--- a/src/datasource/dataProcessor.ts
+++ b/src/datasource/dataProcessor.ts
@@ -39,8 +39,8 @@ function replaceAlias(regexp: string, newAlias: string, frame: DataFrame) {
   if (frame.fields?.length <= 2) {
     let alias = frame.name.replace(pattern, newAlias);
     const valueField = frame.fields.find((f) => f.name !== TIME_SERIES_TIME_FIELD_NAME);
-    if (valueField?.state?.scopedVars) {
-      alias = getTemplateSrv().replace(alias, valueField?.state?.scopedVars);
+    if (valueField?.config?.custom?.scopedVars) {
+      alias = getTemplateSrv().replace(alias, valueField?.config?.custom?.scopedVars);
     }
     if (valueField) {
       valueField.config.displayNameFromDS = alias;
@@ -52,8 +52,8 @@ function replaceAlias(regexp: string, newAlias: string, frame: DataFrame) {
   for (const field of frame.fields) {
     if (field.type !== FieldType.time) {
       let alias = field.config?.displayNameFromDS?.replace(pattern, newAlias);
-      if (field?.state?.scopedVars && alias) {
-        alias = getTemplateSrv().replace(alias, field?.state?.scopedVars);
+      if (field?.config?.custom?.scopedVars && alias) {
+        alias = getTemplateSrv().replace(alias, field?.config?.custom?.scopedVars);
       }
       field.name = alias || field.name;
     }

--- a/src/datasource/dataProcessor.ts
+++ b/src/datasource/dataProcessor.ts
@@ -39,8 +39,9 @@ function replaceAlias(regexp: string, newAlias: string, frame: DataFrame) {
   if (frame.fields?.length <= 2) {
     let alias = frame.name.replace(pattern, newAlias);
     const valueField = frame.fields.find((f) => f.name !== TIME_SERIES_TIME_FIELD_NAME);
-    if (valueField?.config?.custom?.scopedVars) {
-      alias = getTemplateSrv().replace(alias, valueField?.config?.custom?.scopedVars);
+    const scopedVars = valueField?.config?.custom?.scopedVars;
+    if (scopedVars) {
+      alias = getTemplateSrv().replace(alias, scopedVars);
     }
     if (valueField) {
       valueField.config.displayNameFromDS = alias;
@@ -52,8 +53,9 @@ function replaceAlias(regexp: string, newAlias: string, frame: DataFrame) {
   for (const field of frame.fields) {
     if (field.type !== FieldType.time) {
       let alias = field.config?.displayNameFromDS?.replace(pattern, newAlias);
-      if (field?.config?.custom?.scopedVars && alias) {
-        alias = getTemplateSrv().replace(alias, field?.config?.custom?.scopedVars);
+      const scopedVars = field.config?.custom?.scopedVars;
+      if (scopedVars && alias) {
+        alias = getTemplateSrv().replace(alias, scopedVars);
       }
       field.name = alias || field.name;
     }

--- a/src/datasource/responseHandler.ts
+++ b/src/datasource/responseHandler.ts
@@ -54,6 +54,8 @@ function convertHistory(history, items, addHostName, convertPointCallback) {
       __zbx_item_interval: { value: item.delay },
     };
 
+    utils.addItemTagScopedVars(scopedVars, item.tags);
+
     if (_.keys(hosts).length > 0) {
       const host = _.find(hosts, { hostid: item.hostid });
       scopedVars['__zbx_host'] = { value: host.host };
@@ -146,6 +148,7 @@ export function seriesToDataFrame(
 
     valueFiled.config.custom = {
       itemInterval: scopedVars['__zbx_item_interval']?.value,
+      scopedVars,
     };
   }
 

--- a/src/datasource/specs/dataProcessor.spec.ts
+++ b/src/datasource/specs/dataProcessor.spec.ts
@@ -200,9 +200,10 @@ describe('DataProcessor', () => {
             name: 'value',
             type: FieldType.number,
             values: [10, 20],
-            config: {},
-            state: {
-              scopedVars: { env: { value: 'production' } },
+            config: {
+              custom: {
+                scopedVars: { env: { value: 'production' } },
+              },
             },
           },
         ],
@@ -212,6 +213,47 @@ describe('DataProcessor', () => {
       dataProcessor.metricFunctions.replaceAlias('dev', '$env', frame);
 
       expect(mockReplace).toHaveBeenCalledWith('cpu.usage.$env', { env: { value: 'production' } });
+    });
+
+    it('should resolve item tag tokens from config.custom.scopedVars', () => {
+      const mockReplace = jest.fn((text: string, scopedVars: Record<string, { value: string }>) => {
+        return text.replace('$__zbx_item_tag_service', scopedVars['__zbx_item_tag_service']?.value || '');
+      });
+      mockTemplateSrv.mockReturnValue({
+        replace: mockReplace,
+      } as any);
+
+      const frame: DataFrame = {
+        name: 'vfs.fs.size[/,used]',
+        fields: [
+          {
+            name: TIME_SERIES_TIME_FIELD_NAME,
+            type: FieldType.time,
+            values: [1000, 2000],
+            config: {},
+          },
+          {
+            name: 'value',
+            type: FieldType.number,
+            values: [10, 20],
+            config: {
+              custom: {
+                scopedVars: {
+                  __zbx_item_tag_service: { value: 'checkout' },
+                },
+              },
+            },
+          },
+        ],
+        length: 2,
+      };
+
+      const result = dataProcessor.metricFunctions.setAlias('$__zbx_item_tag_service usage', frame);
+
+      expect(mockReplace).toHaveBeenCalledWith('$__zbx_item_tag_service usage', {
+        __zbx_item_tag_service: { value: 'checkout' },
+      });
+      expect(result.fields[1].config.displayNameFromDS).toBe('checkout usage');
     });
 
     it('should handle multiple value fields', () => {

--- a/src/datasource/specs/dataProcessor.spec.ts
+++ b/src/datasource/specs/dataProcessor.spec.ts
@@ -256,6 +256,41 @@ describe('DataProcessor', () => {
       expect(result.fields[1].config.displayNameFromDS).toBe('checkout usage');
     });
 
+    it('should leave absent item tag tokens unresolved', () => {
+      mockTemplateSrv.mockReturnValue({
+        replace: jest.fn((text: string) => text),
+      } as any);
+
+      const frame: DataFrame = {
+        name: 'CPU load',
+        fields: [
+          {
+            name: TIME_SERIES_TIME_FIELD_NAME,
+            type: FieldType.time,
+            values: [1000, 2000],
+            config: {},
+          },
+          {
+            name: 'value',
+            type: FieldType.number,
+            values: [10, 20],
+            config: {
+              custom: {
+                scopedVars: {
+                  __zbx_item_tag_service: { value: 'checkout' },
+                },
+              },
+            },
+          },
+        ],
+        length: 2,
+      };
+
+      const result = dataProcessor.metricFunctions.setAlias('$__zbx_item_tag_missing usage', frame);
+
+      expect(result.fields[1].config.displayNameFromDS).toBe('$__zbx_item_tag_missing usage');
+    });
+
     it('should handle multiple value fields', () => {
       const frame: DataFrame = {
         name: 'original_name',

--- a/src/datasource/specs/responseHandler.spec.ts
+++ b/src/datasource/specs/responseHandler.spec.ts
@@ -1,0 +1,35 @@
+import { FieldType } from '@grafana/data';
+import { seriesToDataFrame } from '../responseHandler';
+import { ZabbixMetricsQuery } from '../types/query';
+
+describe('responseHandler', () => {
+  describe('seriesToDataFrame()', () => {
+    it('should copy scopedVars including item tags into config.custom.scopedVars', () => {
+      const timeseries = {
+        target: 'CPU load',
+        datapoints: [[10, 1000]],
+        scopedVars: {
+          __zbx_item: { value: 'CPU load' },
+          __zbx_item_name: { value: 'CPU load' },
+          __zbx_item_key: { value: 'system.cpu.load' },
+          __zbx_item_interval: { value: '1m' },
+          __zbx_item_tag_service: { value: 'checkout' },
+          __zbx_item_tag_App_Name: { value: 'api' },
+        },
+        item: {
+          units: '',
+        },
+      };
+
+      const frame = seriesToDataFrame(timeseries, { refId: 'A' } as ZabbixMetricsQuery);
+      const valueField = frame.fields.find((field) => field.type === FieldType.number);
+
+      expect(valueField?.config?.custom?.scopedVars).toEqual(timeseries.scopedVars);
+      expect(valueField?.labels).toEqual({
+        host: undefined,
+        item: 'CPU load',
+        item_key: 'system.cpu.load',
+      });
+    });
+  });
+});

--- a/src/datasource/specs/responseHandler.spec.ts
+++ b/src/datasource/specs/responseHandler.spec.ts
@@ -25,8 +25,7 @@ describe('responseHandler', () => {
       const valueField = frame.fields.find((field) => field.type === FieldType.number);
 
       expect(valueField?.config?.custom?.scopedVars).toEqual(timeseries.scopedVars);
-      expect(valueField?.labels).toEqual({
-        host: undefined,
+      expect(valueField?.labels).toMatchObject({
         item: 'CPU load',
         item_key: 'system.cpu.load',
       });

--- a/src/datasource/specs/utils.spec.ts
+++ b/src/datasource/specs/utils.spec.ts
@@ -267,6 +267,7 @@ describe('Utils', () => {
       expect(utils.sanitizeTagName('service')).toBe('service');
       expect(utils.sanitizeTagName('App Name')).toBe('App_Name');
       expect(utils.sanitizeTagName('App.Name-test')).toBe('App_Name_test');
+      expect(utils.sanitizeTagName('!!!')).toBe('___');
       expect(utils.sanitizeTagName('')).toBe('');
     });
   });

--- a/src/datasource/specs/utils.spec.ts
+++ b/src/datasource/specs/utils.spec.ts
@@ -261,4 +261,46 @@ describe('Utils', () => {
       expect(templateSrv.replace).not.toHaveBeenCalled();
     });
   });
+
+  describe('sanitizeTagName()', () => {
+    it('should replace non-alphanumeric characters with underscores', () => {
+      expect(utils.sanitizeTagName('service')).toBe('service');
+      expect(utils.sanitizeTagName('App Name')).toBe('App_Name');
+      expect(utils.sanitizeTagName('App.Name-test')).toBe('App_Name_test');
+      expect(utils.sanitizeTagName('')).toBe('');
+    });
+  });
+
+  describe('addItemTagScopedVars()', () => {
+    it('should add sanitized tag scoped vars and join duplicate values', () => {
+      const scopedVars: Record<string, { value: string }> = {};
+
+      utils.addItemTagScopedVars(scopedVars, [
+        { tag: 'service', value: 'payment' },
+        { tag: 'App Name', value: 'api' },
+        { tag: 'service', value: 'checkout' },
+      ]);
+
+      expect(scopedVars['__zbx_item_tag_service']).toEqual({ value: 'checkout, payment' });
+      expect(scopedVars['__zbx_item_tag_App_Name']).toEqual({ value: 'api' });
+    });
+
+    it('should no-op when tags are missing', () => {
+      const scopedVars: Record<string, { value: string }> = {};
+
+      utils.addItemTagScopedVars(scopedVars, undefined);
+      utils.addItemTagScopedVars(scopedVars, []);
+
+      expect(scopedVars).toEqual({});
+    });
+
+    it('should add empty string for tags without a value', () => {
+      const scopedVars: Record<string, { value: string }> = {};
+
+      utils.addItemTagScopedVars(scopedVars, [{ tag: 'monitoring' }, { tag: 'service', value: 'checkout' }]);
+
+      expect(scopedVars['__zbx_item_tag_monitoring']).toEqual({ value: '' });
+      expect(scopedVars['__zbx_item_tag_service']).toEqual({ value: 'checkout' });
+    });
+  });
 });

--- a/src/datasource/utils.ts
+++ b/src/datasource/utils.ts
@@ -389,6 +389,33 @@ export function itemTagToString(t: ZBXItemTag): string {
   return t.value ? `${t.tag}: ${t.value}` : t.tag;
 }
 
+export function sanitizeTagName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_]/g, '_');
+}
+
+export function addItemTagScopedVars(scopedVars: Record<string, { value: string }>, tags?: ZBXItemTag[]): void {
+  if (!tags || tags.length === 0) {
+    return;
+  }
+
+  const tagValues: Record<string, string[]> = {};
+  for (const tag of tags) {
+    const sanitized = sanitizeTagName(tag.tag);
+    if (!sanitized) {
+      continue;
+    }
+    const key = `__zbx_item_tag_${sanitized}`;
+    if (!tagValues[key]) {
+      tagValues[key] = [];
+    }
+    tagValues[key].push(tag.value || '');
+  }
+
+  for (const [key, values] of Object.entries(tagValues)) {
+    scopedVars[key] = { value: values.sort().join(', ') };
+  }
+}
+
 export function mustArray(result: any): any[] {
   return result || [];
 }


### PR DESCRIPTION
## Summary
- Add `$__zbx_item_tag_<name>` alias tokens for Zabbix item tag values in `setAlias` and `replaceAlias`
- Populate tag scopedVars in both Go and TS response handlers, with sanitized tag names and sorted multi-value joins
- Fix `replaceAlias` to read `config.custom.scopedVars` and copy scopedVars into frontend-built DataFrames
- Fetch item tags in `GetItemsByIDs` on Zabbix 5.4+

Closes #2449

## Test plan
- [ ] `go test ./pkg/datasource/ -run 'TestSanitizeTagName|TestAddItemTagScopedVars|TestSeriesToDataFrameItemTagScopedVars'`
- [ ] `yarn jest --testPathPatterns='utils.spec|dataProcessor.spec|responseHandler.spec'`
- [ ] In Grafana, query items with tags and use `setAlias($__zbx_item_tag_<name>)` to verify legend text
- [ ] Confirm tags with no value resolve to empty string and absent tags leave the literal token
- [ ] Verify item-ID queries include tags on Zabbix 5.4+


Made with [Cursor](https://cursor.com)