### PR TITLE
feat(problems): filter problem names at the Zabbix API source

### DIFF
--- a/.changeset/problems-source-side-name-filter.md
+++ b/.changeset/problems-source-side-name-filter.md
@@ -1,0 +1,5 @@
+---
+'grafana-zabbix': minor
+---
+
+Problems query: push the problem-name filter to the Zabbix API (`problem.get`/`event.get` `search`) instead of fetching every problem and filtering client-side. This drastically reduces the data transferred for large environments (avoiding gRPC message-size limits) and makes the `limit` apply to name-matched problems. Plain names and `*` wildcards are filtered fully at the source; regex filters are narrowed at the source by their guaranteed literal substring — including top-level alternations like `/(A|B|C)/`, which are pushed as an OR of branch literals (`searchByAny`) — and are still matched precisely client-side. Look-around regexes (e.g. negative look-ahead `/^(?!...)/` used for exclusion) are evaluated client-side only, so they keep working without being incorrectly narrowed at the source. Problem-name filters now also support `*` wildcards.

--- a/src/datasource/components/QueryEditor/ProblemsQueryEditor.tsx
+++ b/src/datasource/components/QueryEditor/ProblemsQueryEditor.tsx
@@ -218,7 +218,7 @@ export const ProblemsQueryEditor = ({ query, datasource, onChange }: Props) => {
           <Input
             width={24}
             defaultValue={query.trigger?.filter}
-            placeholder="Problem name"
+            placeholder="Problem name, wildcard* or /regex/"
             onBlur={onTextFilterChange('trigger')}
           />
         </InlineField>

--- a/src/datasource/datasource.ts
+++ b/src/datasource/datasource.ts
@@ -591,6 +591,10 @@ export class ZabbixDatasource extends DataSourceWithBackend<ZabbixMetricsQuery, 
       recent: showProblems === ShowProblemTypes.Recent,
       minSeverity: target.options?.minSeverity,
       limit: target.options?.limit,
+      // Filter problem names at the source (Zabbix API) instead of fetching all
+      // problems and filtering client-side. The precise client-side filter still
+      // runs afterwards (see problemsHandler.filterTriggersPre).
+      problemName: target.trigger?.filter,
     };
 
     if (tags && tags.length) {
@@ -818,6 +822,8 @@ export class ZabbixDatasource extends DataSourceWithBackend<ZabbixMetricsQuery, 
       valueFromEvent: true,
       timeFrom,
       timeTo,
+      // Narrow problem names at the source; the precise filter still runs below.
+      problemName: annotation.trigger?.filter,
     };
 
     if (annotation.options.minSeverity) {
@@ -835,14 +841,8 @@ export class ZabbixDatasource extends DataSourceWithBackend<ZabbixMetricsQuery, 
       .then((problems) => {
         // Filter triggers by description
         const problemName = annotation.trigger.filter;
-        if (utils.isRegex(problemName)) {
-          problems = _.filter(problems, (p) => {
-            return utils.buildRegex(problemName).test(p.description);
-          });
-        } else if (problemName) {
-          problems = _.filter(problems, (p) => {
-            return p.description === problemName;
-          });
+        if (problemName) {
+          problems = _.filter(problems, (p) => utils.matchesProblemName(p.description ?? '', problemName));
         }
 
         // Hide acknowledged events if option enabled

--- a/src/datasource/datasource.ts
+++ b/src/datasource/datasource.ts
@@ -839,10 +839,11 @@ export class ZabbixDatasource extends DataSourceWithBackend<ZabbixMetricsQuery, 
     return this.zabbix
       .getProblemsHistory(groupFilter, hostFilter, appFilter, proxyFilter, problemsOptions)
       .then((problems) => {
-        // Filter triggers by description
+        // Filter by problem name — matched on `name`, the same field the server-side
+        // `search` narrowing filters on (see problemsHandler.filterTriggersPre).
         const problemName = annotation.trigger.filter;
         if (problemName) {
-          problems = _.filter(problems, (p) => utils.matchesProblemName(p.description ?? '', problemName));
+          problems = _.filter(problems, (p) => utils.matchesProblemName(p.name ?? '', problemName));
         }
 
         // Hide acknowledged events if option enabled

--- a/src/datasource/problemsHandler.test.ts
+++ b/src/datasource/problemsHandler.test.ts
@@ -1,4 +1,4 @@
-import { expandItemMacros, expandUserMacros, hasUserMacro } from './problemsHandler';
+import { expandItemMacros, expandUserMacros, filterTriggersPre, hasUserMacro } from './problemsHandler';
 
 describe('expandItemMacros', () => {
   const item = (historicalValue?: string, originalLastvalue?: string) => ({ historicalValue, originalLastvalue });
@@ -155,5 +155,53 @@ describe('expandUserMacros', () => {
   it('returns empty/undefined text unchanged', () => {
     expect(expandUserMacros('', [], [], [])).toBe('');
     expect(expandUserMacros(undefined as any, [], [], [])).toBeUndefined();
+  });
+});
+
+describe('filterTriggersPre', () => {
+  const target = (filter: string) => ({ trigger: { filter }, options: { hostsInMaintenance: true } });
+
+  it('matches on the problem name with an exact filter', () => {
+    const problems: any[] = [
+      { name: 'High CPU load', description: 'High CPU load' },
+      { name: 'Low disk space', description: 'Low disk space' },
+    ];
+
+    const result = filterTriggersPre(problems, target('High CPU load'));
+
+    expect(result.map((p) => p.name)).toEqual(['High CPU load']);
+  });
+
+  it('matches on the problem name with a regex filter', () => {
+    const problems: any[] = [
+      { name: 'Unavailable by ICMP', description: 'Unavailable by ICMP' },
+      { name: 'High CPU load', description: 'High CPU load' },
+    ];
+
+    const result = filterTriggersPre(problems, target('/ICMP/'));
+
+    expect(result.map((p) => p.name)).toEqual(['Unavailable by ICMP']);
+  });
+
+  it('matches on name, not description, when the two diverge (event.get path)', () => {
+    // On the events/history path, `name` is the event name (macro values frozen at
+    // event time) while `description` is the trigger name expanded with CURRENT
+    // values. The server-side search narrows on `name`, so the client filter must
+    // match the same field or rows get silently dropped.
+    const problems: any[] = [
+      { name: 'Load on server1 is 95%', description: 'Load on server1 is 97%' },
+      { name: 'Disk full on server2', description: 'Disk full on server2' },
+    ];
+
+    const result = filterTriggersPre(problems, target('/Load on server1 is 95%/'));
+
+    expect(result.map((p) => p.name)).toEqual(['Load on server1 is 95%']);
+  });
+
+  it('keeps problems with a missing name only when the filter is empty', () => {
+    const problems: any[] = [{ description: 'orphan' }, { name: 'High CPU load' }];
+
+    expect(filterTriggersPre(problems, target('High CPU load')).length).toBe(1);
+    expect(filterTriggersPre(problems, target('')).length).toBe(2);
   });
 });

--- a/src/datasource/problemsHandler.ts
+++ b/src/datasource/problemsHandler.ts
@@ -186,15 +186,7 @@ export function filterTriggersPre(triggerList, replacedTarget) {
 }
 
 function filterTriggers(triggers, triggerFilter) {
-  if (utils.isRegex(triggerFilter)) {
-    return _.filter(triggers, (trigger) => {
-      return utils.buildRegex(triggerFilter).test(trigger.description);
-    });
-  } else {
-    return _.filter(triggers, (trigger) => {
-      return trigger.description === triggerFilter;
-    });
-  }
+  return _.filter(triggers, (trigger) => utils.matchesProblemName(trigger.description ?? '', triggerFilter));
 }
 
 export function sortProblems(problems: ProblemDTO[], target) {

--- a/src/datasource/problemsHandler.ts
+++ b/src/datasource/problemsHandler.ts
@@ -171,7 +171,7 @@ export function formatAcknowledges(triggers, users) {
 }
 
 export function filterTriggersPre(triggerList, replacedTarget) {
-  // Filter triggers by description
+  // Filter triggers by problem name
   const triggerFilter = replacedTarget.trigger.filter;
   if (triggerFilter) {
     triggerList = filterTriggers(triggerList, triggerFilter);
@@ -186,7 +186,12 @@ export function filterTriggersPre(triggerList, replacedTarget) {
 }
 
 function filterTriggers(triggers, triggerFilter) {
-  return _.filter(triggers, (trigger) => utils.matchesProblemName(trigger.description ?? '', triggerFilter));
+  // Match on `name` (the event/problem name) — the same field the server-side
+  // `search` narrowing filters on (see buildProblemNameSearchParams) and the field
+  // the Problems panel displays. On the event.get path `description` holds the
+  // trigger name with macros expanded to CURRENT values, which can diverge from the
+  // event name the server filtered on and silently drop rows.
+  return _.filter(triggers, (trigger) => utils.matchesProblemName(trigger.name ?? '', triggerFilter));
 }
 
 export function sortProblems(problems: ProblemDTO[], target) {

--- a/src/datasource/utils.test.ts
+++ b/src/datasource/utils.test.ts
@@ -1,0 +1,163 @@
+import {
+  buildProblemNameSearchParams,
+  extractRegexLiteral,
+  extractRegexLiterals,
+  matchesProblemName,
+  wildcardToRegex,
+} from './utils';
+
+describe('wildcardToRegex', () => {
+  it('matches a prefix wildcard, anchored and case-insensitive', () => {
+    const re = wildcardToRegex('CPU*');
+    expect(re.test('CPU load high')).toBe(true);
+    expect(re.test('cpu load high')).toBe(true);
+    expect(re.test('High CPU load')).toBe(false);
+  });
+
+  it('matches wildcards in the middle', () => {
+    const re = wildcardToRegex('High*load');
+    expect(re.test('High CPU load')).toBe(true);
+    expect(re.test('High memory usage')).toBe(false);
+  });
+
+  it('escapes regex metacharacters in the literal parts', () => {
+    const re = wildcardToRegex('a.b*');
+    expect(re.test('a.b and more')).toBe(true);
+    expect(re.test('axb and more')).toBe(false);
+  });
+});
+
+describe('matchesProblemName', () => {
+  it('does an exact match for a plain string', () => {
+    expect(matchesProblemName('High CPU load', 'High CPU load')).toBe(true);
+    expect(matchesProblemName('High CPU load on host', 'High CPU load')).toBe(false);
+  });
+
+  it('does a wildcard match when the filter contains *', () => {
+    expect(matchesProblemName('High CPU load on host', 'High CPU*')).toBe(true);
+    expect(matchesProblemName('Low memory', 'High CPU*')).toBe(false);
+  });
+
+  it('does a regex match for /pattern/ filters', () => {
+    expect(matchesProblemName('CPU load 95%', '/CPU load \\d+%/')).toBe(true);
+    expect(matchesProblemName('cpu load 95%', '/CPU load \\d+%/i')).toBe(true);
+    expect(matchesProblemName('Memory low', '/CPU load \\d+%/')).toBe(false);
+  });
+
+  it('matches an alternation regex', () => {
+    const f = '/(Datastore free space|Unavailable by ICMP|Zabbix agent is not available)/';
+    expect(matchesProblemName('Datastore free space is low', f)).toBe(true);
+    expect(matchesProblemName('Unavailable by ICMP', f)).toBe(true);
+    expect(matchesProblemName('High CPU load', f)).toBe(false);
+  });
+
+  it('honors a negative look-ahead (exclusion) regex', () => {
+    const f = '/^(?!.*Zabbix agent).*/';
+    expect(matchesProblemName('High CPU load', f)).toBe(true);
+    expect(matchesProblemName('Zabbix agent is not available', f)).toBe(false);
+  });
+});
+
+describe('extractRegexLiteral', () => {
+  it('returns the literal of a simple regex', () => {
+    expect(extractRegexLiteral('/CPU load/')).toBe('CPU load');
+  });
+
+  it('strips anchors and trailing quantified expressions', () => {
+    expect(extractRegexLiteral('/^CPU load.*$/')).toBe('CPU load');
+  });
+
+  it('drops the character preceding an optional quantifier', () => {
+    // "loads?" -> the trailing "s" is optional, so it is not guaranteed.
+    expect(extractRegexLiteral('/CPU loads?/')).toBe('CPU load');
+  });
+
+  it('skips character classes', () => {
+    expect(extractRegexLiteral('/Disk[0-9]+ full/')).toBe(' full');
+  });
+
+  it('returns null for alternations', () => {
+    expect(extractRegexLiteral('/(network|system)/')).toBeNull();
+  });
+
+  it('returns null when no literal reaches the minimum length', () => {
+    expect(extractRegexLiteral('/a.b/')).toBeNull();
+  });
+
+  it('returns null for non-regex input', () => {
+    expect(extractRegexLiteral('CPU load')).toBeNull();
+  });
+
+  it('returns null for an alternation (more than one branch)', () => {
+    expect(extractRegexLiteral('/(network|system)/')).toBeNull();
+  });
+});
+
+describe('extractRegexLiterals', () => {
+  it('returns one literal per branch of a top-level alternation', () => {
+    expect(extractRegexLiterals('/(Datastore free space|Unavailable by ICMP|Zabbix agent is not available)/')).toEqual([
+      'Datastore free space',
+      'Unavailable by ICMP',
+      'Zabbix agent is not available',
+    ]);
+  });
+
+  it('handles an alternation without an enclosing group', () => {
+    expect(extractRegexLiterals('/Datastore free space|Unavailable by ICMP/')).toEqual([
+      'Datastore free space',
+      'Unavailable by ICMP',
+    ]);
+  });
+
+  it('returns a single-element array for a non-alternation regex', () => {
+    expect(extractRegexLiterals('/CPU load.*/')).toEqual(['CPU load']);
+  });
+
+  it('returns null when any branch has no guaranteed literal', () => {
+    expect(extractRegexLiterals('/(CPU load|.*)/')).toBeNull();
+  });
+
+  it('returns null for look-around constructs', () => {
+    expect(extractRegexLiterals('/^(?!.*Zabbix agent).*/')).toBeNull();
+    expect(extractRegexLiterals('/foo(?=bar)/')).toBeNull();
+  });
+});
+
+describe('buildProblemNameSearchParams', () => {
+  it('returns an empty object for an empty filter', () => {
+    expect(buildProblemNameSearchParams(undefined)).toEqual({});
+    expect(buildProblemNameSearchParams('')).toEqual({});
+  });
+
+  it('maps a plain string to a substring search', () => {
+    expect(buildProblemNameSearchParams('High CPU load')).toEqual({ search: { name: 'High CPU load' } });
+  });
+
+  it('enables wildcards for a pattern containing *', () => {
+    expect(buildProblemNameSearchParams('CPU*')).toEqual({
+      search: { name: 'CPU*' },
+      searchWildcardsEnabled: true,
+    });
+  });
+
+  it('narrows a regex by its guaranteed literal', () => {
+    expect(buildProblemNameSearchParams('/CPU load.*/')).toEqual({ search: { name: 'CPU load' } });
+  });
+
+  it('narrows an alternation regex by an OR of branch literals', () => {
+    expect(
+      buildProblemNameSearchParams('/(Datastore free space|Unavailable by ICMP|Zabbix agent is not available)/')
+    ).toEqual({
+      search: { name: ['Datastore free space', 'Unavailable by ICMP', 'Zabbix agent is not available'] },
+      searchByAny: true,
+    });
+  });
+
+  it('skips narrowing when an alternation branch has no safe literal', () => {
+    expect(buildProblemNameSearchParams('/(CPU load|.*)/')).toEqual({});
+  });
+
+  it('skips narrowing for a negative look-ahead (exclusion) regex', () => {
+    expect(buildProblemNameSearchParams('/^(?!.*Zabbix agent).*/')).toEqual({});
+  });
+});

--- a/src/datasource/utils.test.ts
+++ b/src/datasource/utils.test.ts
@@ -121,6 +121,37 @@ describe('extractRegexLiterals', () => {
     expect(extractRegexLiterals('/^(?!.*Zabbix agent).*/')).toBeNull();
     expect(extractRegexLiterals('/foo(?=bar)/')).toBeNull();
   });
+
+  describe('quantified groups', () => {
+    it('retracts the contents of an optional group', () => {
+      expect(extractRegexLiterals('/(Critical failure)?CPU load/')).toEqual(['CPU load']);
+    });
+
+    it('retracts the contents of a *-quantified group', () => {
+      expect(extractRegexLiterals('/(Very long prefix)*CPU load/')).toEqual(['CPU load']);
+    });
+
+    it('retracts the contents of a {}-quantified group', () => {
+      expect(extractRegexLiterals('/(Prefix here){0,2}CPU load/')).toEqual(['CPU load']);
+    });
+
+    it('retracts every run committed inside an optional group', () => {
+      // The group commits two runs ("Foo bar", "Baz qux") — both must be retracted.
+      expect(extractRegexLiterals('/(Foo bar|Baz qux)?Common part/')).toEqual(['Common part']);
+    });
+
+    it('retracts nested optional groups', () => {
+      expect(extractRegexLiterals('/((Inner)?Outer)?Trailing text/')).toEqual(['Trailing text']);
+    });
+
+    it('keeps the contents of a +-quantified group (guaranteed at least once)', () => {
+      expect(extractRegexLiterals('/(Mandatory prefix)+CPU/')).toEqual(['Mandatory prefix']);
+    });
+
+    it('keeps the contents of an unquantified group', () => {
+      expect(extractRegexLiterals('/(Foo bar)Baz/')).toEqual(['Foo bar']);
+    });
+  });
 });
 
 describe('buildProblemNameSearchParams', () => {
@@ -159,5 +190,13 @@ describe('buildProblemNameSearchParams', () => {
 
   it('skips narrowing for a negative look-ahead (exclusion) regex', () => {
     expect(buildProblemNameSearchParams('/^(?!.*Zabbix agent).*/')).toEqual({});
+  });
+
+  it('narrows a regex with an optional group by the remaining guaranteed literal', () => {
+    expect(buildProblemNameSearchParams('/(Critical failure)?CPU load/')).toEqual({ search: { name: 'CPU load' } });
+  });
+
+  it('skips narrowing when the only literal is inside an optional group', () => {
+    expect(buildProblemNameSearchParams('/(Critical failure)?.*/')).toEqual({});
   });
 });

--- a/src/datasource/utils.ts
+++ b/src/datasource/utils.ts
@@ -231,6 +231,258 @@ export function buildRegex(str) {
   return new RegExp(pattern, flags);
 }
 
+/**
+ * Converts a wildcard pattern (where `*` matches any sequence of characters, the
+ * same semantics as the Zabbix API `search` parameter with `searchWildcardsEnabled`)
+ * into an anchored, case-insensitive RegExp. Used to evaluate wildcard problem-name
+ * filters client-side consistently with the server-side narrowing.
+ */
+export function wildcardToRegex(pattern: string): RegExp {
+  const escaped = pattern
+    .split('*')
+    .map((part) => part.replace(/[\\^$+?.()|[\]{}]/g, '\\$&'))
+    .join('.*');
+  return new RegExp(`^${escaped}$`, 'i');
+}
+
+/**
+ * Returns true when `value` matches the given problem-name `filter`. The filter may
+ * be a JS regex (`/pattern/flags`), a wildcard pattern (containing `*`), or a plain
+ * string (exact match). Shared by the panel/query and annotation code paths so the
+ * client-side filter stays consistent with the server-side Zabbix `search` narrowing.
+ */
+export function matchesProblemName(value: string, filter: string): boolean {
+  if (isRegex(filter)) {
+    return buildRegex(filter).test(value);
+  }
+  if (filter.includes('*')) {
+    return wildcardToRegex(filter).test(value);
+  }
+  return value === filter;
+}
+
+// Minimum length for an extracted literal, so a tiny fragment doesn't over-narrow.
+const MIN_LITERAL_LENGTH = 3;
+
+/**
+ * Walks a single regex branch (no top-level alternation) and returns the longest
+ * substring that MUST appear literally in every match of that branch, or null if none
+ * qualifies. Conservative: character classes are skipped (alternatives, not guaranteed),
+ * optionally-quantified characters are dropped, and escaped characters end the run.
+ */
+function guaranteedLiteralForBranch(pattern: string): string | null {
+  // Metacharacters that terminate a literal run while keeping the run intact.
+  const terminators = new Set(['.', '+', '(', ')', '^', '$', '}', '|']);
+  const runs: string[] = [];
+  let current = '';
+  const flush = (dropLast: boolean) => {
+    if (dropLast) {
+      current = current.slice(0, -1);
+    }
+    if (current) {
+      runs.push(current);
+    }
+    current = '';
+  };
+
+  for (let i = 0; i < pattern.length; i++) {
+    const ch = pattern[i];
+    if (ch === '\\') {
+      // Escaped char: end the current run and skip the escaped char (stay conservative).
+      flush(false);
+      i++;
+    } else if (ch === '[') {
+      // Character class: its contents are alternatives, not a guaranteed literal — skip it.
+      flush(false);
+      i++;
+      while (i < pattern.length && pattern[i] !== ']') {
+        if (pattern[i] === '\\') {
+          i++;
+        }
+        i++;
+      }
+    } else if (ch === '?' || ch === '*' || ch === '{') {
+      // Preceding char is optional / variably quantified — drop it from the literal.
+      flush(true);
+      if (ch === '{') {
+        while (i < pattern.length && pattern[i] !== '}') {
+          i++;
+        }
+      }
+    } else if (terminators.has(ch)) {
+      flush(false);
+    } else {
+      current += ch;
+    }
+  }
+  flush(false);
+
+  const longest = runs.reduce((a, b) => (b.length > a.length ? b : a), '');
+  return longest.length >= MIN_LITERAL_LENGTH ? longest : null;
+}
+
+/** Strips outer anchors and a single whole-pattern capturing group, e.g. `^(a|b)$` → `a|b`. */
+function stripAnchorsAndOuterGroup(pattern: string): string {
+  let p = pattern;
+  if (p.startsWith('^')) {
+    p = p.slice(1);
+  }
+  if (p.endsWith('$')) {
+    p = p.slice(0, -1);
+  }
+  // Unwrap a capturing group only when it encloses the ENTIRE remaining pattern.
+  while (p.startsWith('(') && !p.startsWith('(?')) {
+    let depth = 0;
+    let end = -1;
+    let inClass = false;
+    for (let i = 0; i < p.length; i++) {
+      const ch = p[i];
+      if (ch === '\\') {
+        i++;
+      } else if (inClass) {
+        if (ch === ']') {
+          inClass = false;
+        }
+      } else if (ch === '[') {
+        inClass = true;
+      } else if (ch === '(') {
+        depth++;
+      } else if (ch === ')') {
+        depth--;
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+    if (end === p.length - 1) {
+      p = p.slice(1, -1);
+    } else {
+      break;
+    }
+  }
+  return p;
+}
+
+/** Splits a pattern on TOP-LEVEL `|` only (ignoring `|` inside groups or character classes). */
+function splitTopLevelAlternation(pattern: string): string[] {
+  const branches: string[] = [];
+  let depth = 0;
+  let inClass = false;
+  let current = '';
+  for (let i = 0; i < pattern.length; i++) {
+    const ch = pattern[i];
+    if (ch === '\\') {
+      current += ch + (pattern[i + 1] ?? '');
+      i++;
+    } else if (inClass) {
+      current += ch;
+      if (ch === ']') {
+        inClass = false;
+      }
+    } else if (ch === '[') {
+      inClass = true;
+      current += ch;
+    } else if (ch === '(') {
+      depth++;
+      current += ch;
+    } else if (ch === ')') {
+      depth--;
+      current += ch;
+    } else if (ch === '|' && depth === 0) {
+      branches.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  branches.push(current);
+  return branches;
+}
+
+/**
+ * Extracts literal substrings such that EVERY string matched by the regex contains at
+ * least one of them — usable as a coarse server-side `search` (OR) pre-filter that
+ * narrows the result set before the precise regex runs client-side. Zabbix cannot
+ * evaluate regular expressions, so this is the only way to push regex filters down.
+ *
+ * Returns null (no safe narrowing) when:
+ *  - the pattern uses look-around / inline-group constructs (`(?...)`), because a literal
+ *    inside a NEGATIVE look-ahead would otherwise be pushed as a positive search and
+ *    return exactly the rows the user wants excluded; or
+ *  - any top-level alternation branch has no guaranteed literal (narrowing on the other
+ *    branches would drop that branch's valid matches).
+ */
+export function extractRegexLiterals(regexStr: string): string[] | null {
+  if (!isRegex(regexStr)) {
+    return null;
+  }
+  const pattern = regexStr.match(regexPattern)?.[1];
+  if (!pattern) {
+    return null;
+  }
+  // Look-arounds / inline groups: literals around them aren't guaranteed, and a negative
+  // look-around literal would be actively wrong — don't narrow at the source.
+  if (pattern.includes('(?')) {
+    return null;
+  }
+
+  const branches = splitTopLevelAlternation(stripAnchorsAndOuterGroup(pattern));
+  const literals: string[] = [];
+  for (const branch of branches) {
+    const literal = guaranteedLiteralForBranch(branch);
+    if (!literal) {
+      // One un-narrowable branch means narrowing the rest would drop its matches.
+      return null;
+    }
+    literals.push(literal);
+  }
+  return Array.from(new Set(literals));
+}
+
+/**
+ * Best-effort extraction of a single literal substring guaranteed to appear in every
+ * match of a non-alternation regex. Returns null for alternations, look-arounds, or when
+ * no literal qualifies. (Thin wrapper over {@link extractRegexLiterals}.)
+ */
+export function extractRegexLiteral(regexStr: string): string | null {
+  const literals = extractRegexLiterals(regexStr);
+  return literals && literals.length === 1 ? literals[0] : null;
+}
+
+/**
+ * Builds the Zabbix API `search` parameters for a problem-name filter so filtering can
+ * happen at the source instead of after fetching every problem. Plain strings and
+ * wildcard patterns map directly to a `search` on the problem `name`; regex filters are
+ * narrowed by their guaranteed literal substring(s) — a top-level alternation pushes all
+ * branch literals as an OR (`searchByAny`). Returns an empty object when no server-side
+ * narrowing is possible (e.g. look-around regexes), leaving the client-side filter to do
+ * the precise work.
+ */
+export function buildProblemNameSearchParams(filter?: string): {
+  search?: { name: string | string[] };
+  searchWildcardsEnabled?: boolean;
+  searchByAny?: boolean;
+} {
+  if (!filter) {
+    return {};
+  }
+  if (isRegex(filter)) {
+    const literals = extractRegexLiterals(filter);
+    if (!literals || !literals.length) {
+      return {};
+    }
+    if (literals.length === 1) {
+      return { search: { name: literals[0] } };
+    }
+    return { search: { name: literals }, searchByAny: true };
+  }
+  if (filter.includes('*')) {
+    return { search: { name: filter }, searchWildcardsEnabled: true };
+  }
+  return { search: { name: filter } };
+}
+
 // Need for template variables replace
 // From Grafana's templateSrv.js
 export function escapeRegex(value) {

--- a/src/datasource/utils.ts
+++ b/src/datasource/utils.ts
@@ -268,12 +268,20 @@ const MIN_LITERAL_LENGTH = 3;
  * Walks a single regex branch (no top-level alternation) and returns the longest
  * substring that MUST appear literally in every match of that branch, or null if none
  * qualifies. Conservative: character classes are skipped (alternatives, not guaranteed),
- * optionally-quantified characters are dropped, and escaped characters end the run.
+ * optionally-quantified characters are dropped, escaped characters end the run, and a
+ * group quantified with `?`, `*` or `{...}` has ALL of its contents retracted — nothing
+ * inside an optional group is guaranteed. A group quantified with `+` (one or more)
+ * keeps its contents. Look-around groups never reach this function (the caller bails
+ * on `(?` patterns).
  */
 function guaranteedLiteralForBranch(pattern: string): string | null {
   // Metacharacters that terminate a literal run while keeping the run intact.
-  const terminators = new Set(['.', '+', '(', ')', '^', '$', '}', '|']);
+  // `(` and `)` are handled separately to support retracting optional groups.
+  const terminators = new Set(['.', '+', '^', '$', '}', '|']);
   const runs: string[] = [];
+  // For each open group, the number of runs committed before it — used to retract
+  // every run the group contributed when it turns out to be optionally quantified.
+  const groupMarks: number[] = [];
   let current = '';
   const flush = (dropLast: boolean) => {
     if (dropLast) {
@@ -300,6 +308,25 @@ function guaranteedLiteralForBranch(pattern: string): string | null {
           i++;
         }
         i++;
+      }
+    } else if (ch === '(') {
+      flush(false);
+      groupMarks.push(runs.length);
+    } else if (ch === ')') {
+      flush(false);
+      const mark = groupMarks.pop() ?? 0;
+      const next = pattern[i + 1];
+      // `?` / `*` make the whole group optional and `{...}` may (e.g. {0,2}) — none of
+      // the runs committed inside it are guaranteed, so retract them all. `+` keeps the
+      // group mandatory (at least one occurrence), so its runs stay.
+      if (next === '?' || next === '*' || next === '{') {
+        runs.length = mark;
+        i++;
+        if (next === '{') {
+          while (i < pattern.length && pattern[i] !== '}') {
+            i++;
+          }
+        }
       }
     } else if (ch === '?' || ch === '*' || ch === '{') {
       // Preceding char is optional / variably quantified — drop it from the literal.

--- a/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.test.ts
+++ b/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.test.ts
@@ -189,6 +189,81 @@ describe('Zabbix API connector', () => {
       const [, params] = (zabbixAPIConnector.request as jest.Mock).mock.calls.at(-1)!;
       expect(params.symptom).toBeUndefined();
     });
+
+    it('pushes a plain problem name to the API search parameter', async () => {
+      const zabbixAPIConnector = new ZabbixAPIConnector('admin', true, datasourceUID);
+      zabbixAPIConnector.version = '7.0.0';
+      zabbixAPIConnector.request = jest.fn(() => Promise.resolve([]));
+
+      await zabbixAPIConnector.getProblems(['21'], ['31'], ['41'], false, { problemName: 'High CPU load' });
+
+      const [, params] = (zabbixAPIConnector.request as jest.Mock).mock.calls.at(-1)!;
+      expect(params.search).toEqual({ name: 'High CPU load' });
+      expect(params.searchWildcardsEnabled).toBeUndefined();
+    });
+
+    it('enables wildcards when the problem name contains *', async () => {
+      const zabbixAPIConnector = new ZabbixAPIConnector('admin', true, datasourceUID);
+      zabbixAPIConnector.version = '7.0.0';
+      zabbixAPIConnector.request = jest.fn(() => Promise.resolve([]));
+
+      await zabbixAPIConnector.getProblems(['21'], ['31'], ['41'], false, { problemName: 'CPU*' });
+
+      const [, params] = (zabbixAPIConnector.request as jest.Mock).mock.calls.at(-1)!;
+      expect(params.search).toEqual({ name: 'CPU*' });
+      expect(params.searchWildcardsEnabled).toBe(true);
+    });
+
+    it('narrows a regex problem name by its literal substring', async () => {
+      const zabbixAPIConnector = new ZabbixAPIConnector('admin', true, datasourceUID);
+      zabbixAPIConnector.version = '7.0.0';
+      zabbixAPIConnector.request = jest.fn(() => Promise.resolve([]));
+
+      await zabbixAPIConnector.getProblems(['21'], ['31'], ['41'], false, { problemName: '/CPU load.*/' });
+
+      const [, params] = (zabbixAPIConnector.request as jest.Mock).mock.calls.at(-1)!;
+      expect(params.search).toEqual({ name: 'CPU load' });
+      expect(params.searchWildcardsEnabled).toBeUndefined();
+    });
+
+    it('omits search when no problem name is given', async () => {
+      const zabbixAPIConnector = new ZabbixAPIConnector('admin', true, datasourceUID);
+      zabbixAPIConnector.version = '7.0.0';
+      zabbixAPIConnector.request = jest.fn(() => Promise.resolve([]));
+
+      await zabbixAPIConnector.getProblems(['21'], ['31'], ['41'], false, {});
+
+      const [, params] = (zabbixAPIConnector.request as jest.Mock).mock.calls.at(-1)!;
+      expect(params.search).toBeUndefined();
+    });
+
+    it('pushes an alternation regex as an OR of branch literals (searchByAny)', async () => {
+      const zabbixAPIConnector = new ZabbixAPIConnector('admin', true, datasourceUID);
+      zabbixAPIConnector.version = '7.0.0';
+      zabbixAPIConnector.request = jest.fn(() => Promise.resolve([]));
+
+      await zabbixAPIConnector.getProblems(['21'], ['31'], ['41'], false, {
+        problemName: '/(Datastore free space|Unavailable by ICMP|Zabbix agent is not available)/',
+      });
+
+      const [, params] = (zabbixAPIConnector.request as jest.Mock).mock.calls.at(-1)!;
+      expect(params.search).toEqual({
+        name: ['Datastore free space', 'Unavailable by ICMP', 'Zabbix agent is not available'],
+      });
+      expect(params.searchByAny).toBe(true);
+    });
+
+    it('omits search for a negative look-ahead (exclusion) regex', async () => {
+      const zabbixAPIConnector = new ZabbixAPIConnector('admin', true, datasourceUID);
+      zabbixAPIConnector.version = '7.0.0';
+      zabbixAPIConnector.request = jest.fn(() => Promise.resolve([]));
+
+      await zabbixAPIConnector.getProblems(['21'], ['31'], ['41'], false, { problemName: '/^(?!.*Zabbix agent).*/' });
+
+      const [, params] = (zabbixAPIConnector.request as jest.Mock).mock.calls.at(-1)!;
+      expect(params.search).toBeUndefined();
+      expect(params.searchByAny).toBeUndefined();
+    });
   });
 
   describe('getEventsHistory', () => {

--- a/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.test.ts
+++ b/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.test.ts
@@ -226,6 +226,21 @@ describe('Zabbix API connector', () => {
       expect(params.searchWildcardsEnabled).toBeUndefined();
     });
 
+    it('does not narrow by a literal inside an optional group', async () => {
+      const zabbixAPIConnector = new ZabbixAPIConnector('admin', true, datasourceUID);
+      zabbixAPIConnector.version = '7.0.0';
+      zabbixAPIConnector.request = jest.fn(() => Promise.resolve([]));
+
+      await zabbixAPIConnector.getProblems(['21'], ['31'], ['41'], false, {
+        problemName: '/(Critical failure)?CPU load/',
+      });
+
+      const [, params] = (zabbixAPIConnector.request as jest.Mock).mock.calls.at(-1)!;
+      // "Critical failure" is optional — narrowing on it would drop plain "CPU load"
+      // problems the regex matches. Only the guaranteed literal may be pushed.
+      expect(params.search).toEqual({ name: 'CPU load' });
+    });
+
     it('omits search when no problem name is given', async () => {
       const zabbixAPIConnector = new ZabbixAPIConnector('admin', true, datasourceUID);
       zabbixAPIConnector.version = '7.0.0';

--- a/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
+++ b/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
@@ -518,8 +518,7 @@ export class ZabbixAPIConnector {
   }
 
   getProblems(groupids, hostids, applicationids, supportsApplications, options): Promise<ZBXProblem[]> {
-    const { timeFrom, timeTo, recent, severities, limit, acknowledged, tags, evaltype, problemName, symptom } =
-      options;
+    const { timeFrom, timeTo, recent, severities, limit, acknowledged, tags, evaltype, problemName, symptom } = options;
 
     const params: any = {
       output: 'extend',

--- a/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
+++ b/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
@@ -518,7 +518,8 @@ export class ZabbixAPIConnector {
   }
 
   getProblems(groupids, hostids, applicationids, supportsApplications, options): Promise<ZBXProblem[]> {
-    const { timeFrom, timeTo, recent, severities, limit, acknowledged, tags, evaltype, symptom } = options;
+    const { timeFrom, timeTo, recent, severities, limit, acknowledged, tags, evaltype, problemName, symptom } =
+      options;
 
     const params: any = {
       output: 'extend',
@@ -563,6 +564,19 @@ export class ZabbixAPIConnector {
 
     if (supportsApplications) {
       params.applicationids = applicationids;
+    }
+
+    // Push the problem-name filter to the Zabbix API so it filters at the source
+    // instead of the plugin fetching every problem and filtering client-side.
+    const nameSearch = utils.buildProblemNameSearchParams(problemName);
+    if (nameSearch.search) {
+      params.search = nameSearch.search;
+      if (nameSearch.searchWildcardsEnabled) {
+        params.searchWildcardsEnabled = true;
+      }
+      if (nameSearch.searchByAny) {
+        params.searchByAny = true;
+      }
     }
 
     if (this.supportsCauseSymptomProblems() && symptom !== undefined && symptom !== null) {
@@ -683,7 +697,7 @@ export class ZabbixAPIConnector {
   }
 
   getEventsHistory(groupids, hostids, applicationids, options) {
-    const { timeFrom, timeTo, severities, limit, value, tags, evaltype, symptom } = options;
+    const { timeFrom, timeTo, severities, limit, value, tags, evaltype, problemName, symptom } = options;
 
     const params: any = {
       output: 'extend',
@@ -721,6 +735,18 @@ export class ZabbixAPIConnector {
 
     if (evaltype) {
       params.evaltype = evaltype;
+    }
+
+    // Push the problem-name filter to the Zabbix API (see getProblems).
+    const nameSearch = utils.buildProblemNameSearchParams(problemName);
+    if (nameSearch.search) {
+      params.search = nameSearch.search;
+      if (nameSearch.searchWildcardsEnabled) {
+        params.searchWildcardsEnabled = true;
+      }
+      if (nameSearch.searchByAny) {
+        params.searchByAny = true;
+      }
     }
 
     if (this.supportsCauseSymptomProblems() && symptom !== undefined && symptom !== null) {


### PR DESCRIPTION
## Summary

Pushes the Problems-query **name filter** down to the Zabbix API
(`problem.get` / `event.get` `search`) instead of fetching every problem in
scope and filtering in the browser. This drastically cuts the data
transferred in large environments (avoiding gRPC limits / timeouts) and
makes `limit` apply to name-matched problems.

Fixes #2466 

## How the filter maps to the API

| Filter type | Pushed to Zabbix | Client-side pass |
|---|---|---|
| Plain text `High CPU load` | `search:{name}` (substring) | exact match |
| Wildcard `CPU*` | `search:{name}` + `searchWildcardsEnabled` | wildcard match (**new**) |
| Regex `/CPU load.*/` | `search:{name:"CPU load"}` (guaranteed literal) | full regex |
| Alternation `/(A\|B\|C)/` | `search:{name:[A,B,C]}` + `searchByAny` | full regex |
| Look-around `/^(?!...)/` | *(not pushed)* | full regex |

The server step is always a **superset** (case-insensitive substring); the
client-side regex/exact pass tightens it, so results are identical to before
- just cheaper. When a regex can't be safely narrowed (a non-literal
alternation branch, or any look-around construct), it falls back to
client-side filtering only, so correctness is never traded for speed. In
particular, a literal inside a **negative** look-ahead is deliberately not
pushed (doing so would return exactly the rows the user wants excluded).

## Testing

- New unit tests cover plain/wildcard/regex/alternation/look-around mapping,
  the connector params, and client-side matching (including the alternation
  and negative-look-ahead examples).