### PR TITLE
Release 6.4.1

### DIFF
--- a/.changeset/fix-problems-history-overload.md
+++ b/.changeset/fix-problems-history-overload.md
@@ -1,5 +1,0 @@
----
-'grafana-zabbix': patch
----
-
-ProblemsPanel: Fix severe Zabbix DB / PHP-FPM overload caused by the per-problem historical item value lookup (#2427). The `history.get` enrichment introduced in 6.3.1 now runs only when explicitly enabled via the new "Item value at problem time" query option (off by default, restoring 6.3.0 behaviour). When enabled, the history window span and result size are bounded to protect the Zabbix frontend and database in large environments.

--- a/.changeset/quick-lions-jump.md
+++ b/.changeset/quick-lions-jump.md
@@ -1,5 +1,0 @@
----
-'grafana-zabbix': patch
----
-
-Remove the react-use dependency in favor of a local useAsyncFn hook, and upgrade dependencies (including @grafana/\* packages to 13.1.0).

--- a/.changeset/tame-bats-share.md
+++ b/.changeset/tame-bats-share.md
@@ -1,5 +1,0 @@
----
-'grafana-zabbix': patch
----
-
-ProblemsPanel: Fix acknowledges list not scrolling when messages are long. Long acknowledgement messages now wrap instead of overflowing horizontally, so the acknowledges container scrolls vertically as expected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 6.4.1
+
+🐛 ProblemsPanel: Fix severe Zabbix DB / PHP-FPM overload caused by the per-problem historical item value lookup (#2427). The `history.get` enrichment introduced in 6.3.1 now runs only when explicitly enabled via the new "Item value at problem time" query option (off by default, restoring 6.3.0 behaviour). When enabled, the history window span and result size are bounded to protect the Zabbix frontend and database in large environments.
+
+🐛 Remove the react-use dependency in favor of a local useAsyncFn hook, and upgrade dependencies (including @grafana/\* packages to 13.1.0).
+
+🐛 ProblemsPanel: Fix acknowledges list not scrolling when messages are long. Long acknowledgement messages now wrap instead of overflowing horizontally, so the acknowledges container scrolls vertically as expected.
+
 ## 6.4.0
 
 🚀 Remove use of @types/grafana and migrate to use components from @grafana/\* packages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 6.4.1
 
-🐛 ProblemsPanel: Fix severe Zabbix DB / PHP-FPM overload caused by the per-problem historical item value lookup (#2427). The `history.get` enrichment introduced in 6.3.1 now runs only when explicitly enabled via the new "Item value at problem time" query option (off by default, restoring 6.3.0 behaviour). When enabled, the history window span and result size are bounded to protect the Zabbix frontend and database in large environments.
+🐛 ProblemsPanel: Fix severe Zabbix DB / PHP-FPM overload caused by the per-problem historical item value lookup (#2427). The `history.get` enrichment introduced in 6.3.1 now runs only when explicitly enabled via the new "Item value at problem time" query option (off by default, restoring 6.3.0 behavior). When enabled, the history window span and result size are bounded to protect the Zabbix frontend and database in large environments.
 
 🐛 Remove the react-use dependency in favor of a local useAsyncFn hook, and upgrade dependencies (including @grafana/\* packages to 13.1.0).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-zabbix",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "description": "Zabbix plugin for Grafana",
   "homepage": "http://grafana-zabbix.org",
   "bugs": {


### PR DESCRIPTION
🐛 ProblemsPanel: Fix severe Zabbix DB / PHP-FPM overload caused by the per-problem historical item value lookup (#2427). The `history.get` enrichment introduced in 6.3.1 now runs only when explicitly enabled via the new "Item value at problem time" query option (off by default, restoring 6.3.0 behaviour). When enabled, the history window span and result size are bounded to protect the Zabbix frontend and database in large environments.

🐛 Remove the react-use dependency in favor of a local useAsyncFn hook, and upgrade dependencies (including @grafana/\* packages to 13.1.0).

🐛 ProblemsPanel: Fix acknowledges list not scrolling when messages are long. Long acknowledgement messages now wrap instead of overflowing horizontally, so the acknowledges container scrolls vertically as expected.