### PR TITLE
prepare 6.5.0

### DIFF
--- a/.changeset/fix-opdata-user-macros.md
+++ b/.changeset/fix-opdata-user-macros.md
@@ -1,5 +1,0 @@
----
-'grafana-zabbix': patch
----
-
-Fix operational data macro expansion and user macro support in problems panel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 6.5.0
+
+### Minor Changes
+
+🚀 Support item tag values as alias tokens (`$__zbx_item_tag_<name>`) for setAlias/replaceAlias legends
+
+### Patch Changes
+
+⚙️ Chore: update frontend, docker, and GitHub Actions dependencies
+🐛 Fix operational data macro expansion and user macro support in problems panel
+
 ## 6.4.1
 
 🐛 ProblemsPanel: Fix severe Zabbix DB / PHP-FPM overload caused by the per-problem historical item value lookup (#2427). The `history.get` enrichment introduced in 6.3.1 now runs only when explicitly enabled via the new "Item value at problem time" query option (off by default, restoring 6.3.0 behavior). When enabled, the history window span and result size are bounded to protect the Zabbix frontend and database in large environments.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-zabbix",
-  "version": "6.4.1",
+  "version": "6.5.0",
   "description": "Zabbix plugin for Grafana",
   "homepage": "http://grafana-zabbix.org",
   "bugs": {


### PR DESCRIPTION

### Minor Changes

🚀 Support item tag values as alias tokens (`$__zbx_item_tag_<name>`) for setAlias/replaceAlias legends

### Patch Changes

⚙️ Chore: update frontend, docker, and GitHub Actions dependencies
🐛 Fix operational data macro expansion and user macro support in problems panel