### PR TITLE
fix: connection storm against Zabbix web frontend causing 502/503 und…

### DIFF
--- a/.changeset/fix-connection-storm-503.md
+++ b/.changeset/fix-connection-storm-503.md
@@ -1,0 +1,5 @@
+---
+'grafana-zabbix': patch
+---
+
+Fix a connection storm against the Zabbix web frontend that could cause widespread 502/503 errors under normal dashboard load. Every backend API request implicitly re-fetched and discarded the Zabbix API version instead of using the existing cache, doubling the number of HTTP requests sent per query; each of those requests then forced its own new TCP connection instead of reusing the pool (`req.Close = true`, a 2021 workaround for a narrow stale-connection race). Together this meant a dashboard with N panels opened roughly 2N fresh connections to Zabbix's web frontend (nginx/php-fpm) per load or refresh, which exhausted php-fpm/connection limits on modest self-hosted Zabbix installs. The version is now cached, connections are pooled normally, and a single safe retry handles the original stale-connection race without disabling keep-alive. The metric-picker resource endpoint also got a bounded timeout, and the frontend now retries transient 502/503/504 responses with backoff.

--- a/pkg/datasource/resource_handler.go
+++ b/pkg/datasource/resource_handler.go
@@ -1,6 +1,7 @@
 package datasource
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -69,7 +70,18 @@ func (ds *ZabbixDatasource) ZabbixAPIHandler(rw http.ResponseWriter, req *http.R
 
 	apiReq := &zabbix.ZabbixAPIRequest{Method: reqData.Method, Params: reqData.Params}
 
-	result, err := dsInstance.ZabbixAPIQuery(req.Context(), apiReq)
+	// Bound resource calls (metric-picker autocomplete: groups/hosts/items/apps)
+	// with the same query timeout used for regular metric queries in
+	// QueryData (see datasource.go), so a slow/overloaded Zabbix can't hang
+	// this call indefinitely and trip Grafana's own outer gateway timeout.
+	queryTimeout := dsInstance.Settings.QueryTimeout
+	if queryTimeout <= 0 {
+		queryTimeout = 60 * time.Second
+	}
+	resourceCtx, cancel := context.WithTimeout(req.Context(), queryTimeout)
+	defer cancel()
+
+	result, err := dsInstance.ZabbixAPIQuery(resourceCtx, apiReq)
 	if err != nil {
 		ds.logger.Error("Zabbix API request error", "error", err)
 		writeError(rw, http.StatusInternalServerError, err)
@@ -153,8 +165,12 @@ func writeResponse(rw http.ResponseWriter, result *ZabbixAPIResourceResponse) {
 func writeError(rw http.ResponseWriter, statusCode int, err error) {
 	data := make(map[string]interface{})
 
-	data["error"] = "Internal Server Error"
-	data["message"] = err.Error()
+	data["error"] = http.StatusText(statusCode)
+	if err != nil {
+		data["message"] = err.Error()
+	} else {
+		data["message"] = "empty request body"
+	}
 
 	var b []byte
 	if b, err = json.Marshal(data); err != nil {
@@ -163,7 +179,7 @@ func writeError(rw http.ResponseWriter, statusCode int, err error) {
 	}
 
 	rw.Header().Add("Content-Type", "application/json")
-	rw.WriteHeader(http.StatusInternalServerError)
+	rw.WriteHeader(statusCode)
 
 	_, err = rw.Write(b)
 	if err != nil {

--- a/pkg/datasource/resource_handler.go
+++ b/pkg/datasource/resource_handler.go
@@ -3,11 +3,13 @@ package datasource
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"time"
 
 	"github.com/alexanderzobnin/grafana-zabbix/pkg/zabbix"
+	"github.com/alexanderzobnin/grafana-zabbix/pkg/zabbixapi"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
@@ -84,7 +86,11 @@ func (ds *ZabbixDatasource) ZabbixAPIHandler(rw http.ResponseWriter, req *http.R
 	result, err := dsInstance.ZabbixAPIQuery(resourceCtx, apiReq)
 	if err != nil {
 		ds.logger.Error("Zabbix API request error", "error", err)
-		writeError(rw, http.StatusInternalServerError, err)
+		// Surface the real upstream status (e.g. 502/503/504 from an
+		// overloaded Zabbix) instead of always reporting 500, so the
+		// frontend's retry-on-transient-error logic (which keys off the
+		// actual HTTP status of this response) has something to match.
+		writeError(rw, statusCodeFromError(err, http.StatusInternalServerError), err)
 		return
 	}
 
@@ -160,6 +166,16 @@ func writeResponse(rw http.ResponseWriter, result *ZabbixAPIResourceResponse) {
 	if err != nil {
 		log.DefaultLogger.Warn("Error writing response")
 	}
+}
+
+// statusCodeFromError extracts the upstream HTTP status code carried by a
+// *zabbixapi.StatusError, if any, falling back to fallback otherwise.
+func statusCodeFromError(err error, fallback int) int {
+	var statusErr *zabbixapi.StatusError
+	if errors.As(err, &statusErr) {
+		return statusErr.StatusCode
+	}
+	return fallback
 }
 
 func writeError(rw http.ResponseWriter, statusCode int, err error) {

--- a/pkg/datasource/resource_handler_test.go
+++ b/pkg/datasource/resource_handler_test.go
@@ -1,0 +1,50 @@
+package datasource
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/alexanderzobnin/grafana-zabbix/pkg/zabbixapi"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestStatusCodeFromError covers a bug flagged in review: ZabbixAPIHandler
+// used to always report 500 to the browser regardless of the real upstream
+// failure, so the frontend's retry-on-502/503/504 logic could never match
+// anything. statusCodeFromError is what now extracts the real status.
+func TestStatusCodeFromError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		fallback int
+		want     int
+	}{
+		{
+			name:     "extracts the upstream status from a StatusError",
+			err:      &zabbixapi.StatusError{StatusCode: http.StatusServiceUnavailable},
+			fallback: http.StatusInternalServerError,
+			want:     http.StatusServiceUnavailable,
+		},
+		{
+			name:     "extracts the upstream status even when wrapped by another error",
+			err:      fmt.Errorf("zabbix API request error: %w", &zabbixapi.StatusError{StatusCode: http.StatusBadGateway}),
+			fallback: http.StatusInternalServerError,
+			want:     http.StatusBadGateway,
+		},
+		{
+			name:     "falls back for a plain error with no StatusError in its chain",
+			err:      errors.New("boom"),
+			fallback: http.StatusInternalServerError,
+			want:     http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := statusCodeFromError(tt.err, tt.fallback)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/zabbix/methods.go
+++ b/pkg/zabbix/methods.go
@@ -537,7 +537,25 @@ func (ds *Zabbix) GetValueMappings(ctx context.Context) ([]ValueMap, error) {
 	return valuemaps, err
 }
 
+// GetFullVersion returns the Zabbix API version, e.g. "6.4.5".
+//
+// The version rarely changes for a running Zabbix instance, but Request()
+// (see zabbix.go) checks it on every single API call to pick the right
+// request dialect. Without caching, that turns every logical Zabbix API
+// call the plugin makes into two HTTP requests instead of one, which under
+// real dashboard load (many panels, autorefresh, several users) is enough
+// to exhaust the connection/worker limits of the Zabbix web frontend and
+// makes it start answering with 502/503. Cache the result using the same
+// ZabbixCache already used for host.get/item.get/etc. so the version is
+// only re-fetched once per cache TTL.
 func (ds *Zabbix) GetFullVersion(ctx context.Context) (string, error) {
+	versionReq := &ZabbixAPIRequest{Method: "apiinfo.version"}
+	if cached, ok := ds.cache.GetAPIRequest(versionReq); ok {
+		if version, ok := cached.(string); ok && version != "" {
+			return version, nil
+		}
+	}
+
 	result, err := ds.request(ctx, "apiinfo.version", ZabbixAPIParams{})
 	if err != nil {
 		return "", err
@@ -548,7 +566,9 @@ func (ds *Zabbix) GetFullVersion(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	
+
+	ds.cache.SetAPIRequest(versionReq, version)
+
 	return version, nil
 }
 

--- a/pkg/zabbix/methods.go
+++ b/pkg/zabbix/methods.go
@@ -545,12 +545,15 @@ func (ds *Zabbix) GetValueMappings(ctx context.Context) ([]ValueMap, error) {
 // call the plugin makes into two HTTP requests instead of one, which under
 // real dashboard load (many panels, autorefresh, several users) is enough
 // to exhaust the connection/worker limits of the Zabbix web frontend and
-// makes it start answering with 502/503. Cache the result using the same
-// ZabbixCache already used for host.get/item.get/etc. so the version is
-// only re-fetched once per cache TTL.
+// makes it start answering with 502/503. Cache the result in a dedicated
+// cache (not the ZabbixAPIRequest-keyed ZabbixCache used for
+// host.get/item.get/etc.) so the version is only re-fetched once per cache
+// TTL, and so an unrelated apiinfo.version call routed through Request()
+// can never read this string value back expecting a *simplejson.Json.
+const versionCacheKey = "version"
+
 func (ds *Zabbix) GetFullVersion(ctx context.Context) (string, error) {
-	versionReq := &ZabbixAPIRequest{Method: "apiinfo.version"}
-	if cached, ok := ds.cache.GetAPIRequest(versionReq); ok {
+	if cached, ok := ds.versionCache.Get(versionCacheKey); ok {
 		if version, ok := cached.(string); ok && version != "" {
 			return version, nil
 		}
@@ -567,7 +570,7 @@ func (ds *Zabbix) GetFullVersion(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	ds.cache.SetAPIRequest(versionReq, version)
+	ds.versionCache.Set(versionCacheKey, version)
 
 	return version, nil
 }

--- a/pkg/zabbix/zabbix.go
+++ b/pkg/zabbix/zabbix.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alexanderzobnin/grafana-zabbix/pkg/cache"
 	"github.com/alexanderzobnin/grafana-zabbix/pkg/metrics"
 	"github.com/alexanderzobnin/grafana-zabbix/pkg/settings"
 	"github.com/alexanderzobnin/grafana-zabbix/pkg/zabbixapi"
@@ -18,25 +19,34 @@ import (
 // Zabbix is a wrapper for Zabbix API. It wraps Zabbix API queries and performs authentication, adds caching,
 // deduplication and other performance optimizations.
 type Zabbix struct {
-	api      *zabbixapi.ZabbixAPI
-	dsInfo   *backend.DataSourceInstanceSettings
-	settings *settings.ZabbixDatasourceSettings
-	cache    *ZabbixCache
-	version  int
-	logger   log.Logger
+	api          *zabbixapi.ZabbixAPI
+	dsInfo       *backend.DataSourceInstanceSettings
+	settings     *settings.ZabbixDatasourceSettings
+	cache        *ZabbixCache
+	versionCache *cache.Cache
+	version      int
+	logger       log.Logger
 }
 
 // New returns new instance of Zabbix client.
 func New(dsInfo *backend.DataSourceInstanceSettings, zabbixSettings *settings.ZabbixDatasourceSettings, zabbixAPI *zabbixapi.ZabbixAPI) (*Zabbix, error) {
 	logger := log.New()
 	zabbixCache := NewZabbixCache(zabbixSettings.CacheTTL, 10*time.Minute)
+	// Deliberately a separate cache instance from zabbixCache: that one is
+	// keyed by ZabbixAPIRequest and stores *simplejson.Json API responses.
+	// The cached version is a plain string - sharing the same keyspace would
+	// mean a legitimate apiinfo.version call routed through Request() (it's
+	// an allowed resource-endpoint method) could read this cache entry back
+	// and fail its own type assertion, silently returning an empty result.
+	versionCache := cache.NewCache(zabbixSettings.CacheTTL, 10*time.Minute)
 
 	return &Zabbix{
-		api:      zabbixAPI,
-		dsInfo:   dsInfo,
-		settings: zabbixSettings,
-		cache:    zabbixCache,
-		logger:   logger,
+		api:          zabbixAPI,
+		dsInfo:       dsInfo,
+		settings:     zabbixSettings,
+		cache:        zabbixCache,
+		versionCache: versionCache,
+		logger:       logger,
 	}, nil
 }
 
@@ -48,7 +58,7 @@ func (zabbix *Zabbix) GetAPI() *zabbixapi.ZabbixAPI {
 func (ds *Zabbix) Request(ctx context.Context, apiReq *ZabbixAPIRequest) (*simplejson.Json, error) {
 	var resultJson *simplejson.Json
 	var err error
-	
+
 	version, err := ds.GetVersion(ctx)
 	if err != nil {
 		ds.logger.Error("Error querying Zabbix version", "error", err)

--- a/pkg/zabbix/zabbix_test.go
+++ b/pkg/zabbix/zabbix_test.go
@@ -82,6 +82,29 @@ func TestNonCachedQuery(t *testing.T) {
 	assert.Equal(t, "testNew", result)
 }
 
+func TestVersionIsCachedAcrossRequests(t *testing.T) {
+	versionCalls := 0
+	zabbixClient := NewZabbixClientWithHandler(t, func(payload ApiRequestPayload) string {
+		switch payload.Method {
+		case "apiinfo.version":
+			versionCalls++
+			return `{"result":"6.4.0"}`
+		default:
+			return `{"result":"ok"}`
+		}
+	})
+
+	// Every Request() internally checks the API version to pick the right
+	// dialect. Before the fix, that meant a live apiinfo.version HTTP call
+	// on every single Request() - doubling the load sent to Zabbix.
+	for i := 0; i < 5; i++ {
+		_, err := zabbixClient.Request(context.Background(), &ZabbixAPIRequest{Method: "history.get", Params: emptyParams})
+		assert.NoError(t, err)
+	}
+
+	assert.Equal(t, 1, versionCalls, "apiinfo.version should be fetched once and cached, not on every Request()")
+}
+
 func TestItemTagCache(t *testing.T) {
 	callCount := 0
 	zabbixClient := NewZabbixClientWithHandler(t, func(payload ApiRequestPayload) string {

--- a/pkg/zabbix/zabbix_test.go
+++ b/pkg/zabbix/zabbix_test.go
@@ -82,6 +82,34 @@ func TestNonCachedQuery(t *testing.T) {
 	assert.Equal(t, "testNew", result)
 }
 
+// TestVersionCacheDoesNotCollideWithAPIRequestCache covers a bug flagged in
+// review: the version used to be cached under a ZabbixAPIRequest key in the
+// same keyspace as regular *simplejson.Json API responses. A caller
+// invoking apiinfo.version through the generic Request() path with the same
+// key (e.g. &ZabbixAPIRequest{Method: "apiinfo.version"}, Params left nil -
+// exactly what the version cache itself used to write under) would then
+// read the cached string back, fail the *simplejson.Json type assertion,
+// and silently get an empty object instead of the real version.
+func TestVersionCacheDoesNotCollideWithAPIRequestCache(t *testing.T) {
+	zabbixClient := NewZabbixClientWithHandler(t, func(payload ApiRequestPayload) string {
+		if payload.Method == "apiinfo.version" {
+			return `{"result":"6.4.5"}`
+		}
+		return `{"result":"ok"}`
+	})
+
+	version, err := zabbixClient.GetFullVersion(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, "6.4.5", version)
+
+	resp, err := zabbixClient.Request(context.Background(), &ZabbixAPIRequest{Method: "apiinfo.version"})
+	assert.NoError(t, err)
+
+	result, err := resp.String()
+	assert.NoError(t, err)
+	assert.Equal(t, "6.4.5", result, "apiinfo.version routed through Request() must return the real version, not an empty object from a cache-type collision")
+}
+
 func TestVersionIsCachedAcrossRequests(t *testing.T) {
 	versionCalls := 0
 	zabbixClient := NewZabbixClientWithHandler(t, func(payload ApiRequestPayload) string {

--- a/pkg/zabbixapi/testing.go
+++ b/pkg/zabbixapi/testing.go
@@ -22,6 +22,34 @@ func NewTestClient(fn RoundTripFunc) *http.Client {
 	}
 }
 
+type flakyRoundTripper func(req *http.Request) (*http.Response, error)
+
+func (f flakyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+// NewFlakyTestClient returns an *http.Client whose Transport fails the first
+// failTimes requests with failErr (simulating a network-level error such as
+// a stale pooled connection being closed by the peer) before responding
+// normally. The returned *int tracks how many attempts were made.
+func NewFlakyTestClient(failTimes int, failErr error, body string, statusCode int) (*http.Client, *int) {
+	attempts := 0
+	client := &http.Client{
+		Transport: flakyRoundTripper(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			if attempts <= failTimes {
+				return nil, failErr
+			}
+			return &http.Response{
+				StatusCode: statusCode,
+				Body:       io.NopCloser(bytes.NewBufferString(body)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+	return client, &attempts
+}
+
 func MockZabbixAPI(body string, statusCode int) (*ZabbixAPI, error) {
 	apiLogger := log.New()
 	zabbixURL, err := url.Parse("http://zabbix.org/zabbix")

--- a/pkg/zabbixapi/testing.go
+++ b/pkg/zabbixapi/testing.go
@@ -50,6 +50,31 @@ func NewFlakyTestClient(failTimes int, failErr error, body string, statusCode in
 	return client, &attempts
 }
 
+// erroringBody is an io.ReadCloser that always fails to read, simulating a
+// connection dropped mid-response after the server already sent headers.
+type erroringBody struct{ err error }
+
+func (b *erroringBody) Read([]byte) (int, error) { return 0, b.err }
+func (b *erroringBody) Close() error             { return nil }
+
+// NewTruncatedBodyTestClient returns an *http.Client that always answers
+// with statusCode but a body that fails to read with err. The returned *int
+// tracks how many attempts were made.
+func NewTruncatedBodyTestClient(statusCode int, err error) (*http.Client, *int) {
+	attempts := 0
+	client := &http.Client{
+		Transport: flakyRoundTripper(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			return &http.Response{
+				StatusCode: statusCode,
+				Body:       &erroringBody{err: err},
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+	return client, &attempts
+}
+
 func MockZabbixAPI(body string, statusCode int) (*ZabbixAPI, error) {
 	apiLogger := log.New()
 	zabbixURL, err := url.Parse("http://zabbix.org/zabbix")

--- a/pkg/zabbixapi/zabbix_api.go
+++ b/pkg/zabbixapi/zabbix_api.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"syscall"
 
 	"github.com/alexanderzobnin/grafana-zabbix/pkg/metrics"
 	"github.com/bitly/go-simplejson"
@@ -109,25 +110,28 @@ func (api *ZabbixAPI) request(ctx context.Context, method string, params ZabbixA
 		return nil, err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, api.url.String(), bytes.NewBuffer(reqBodyJSON))
-	if err != nil {
-		return nil, err
-	}
-
 	metrics.ZabbixAPIQueryTotal.WithLabelValues(method).Inc()
 
-	if auth != "" && version >= 70 {
-		if version > 70 && api.dsSettings.BasicAuthEnabled {
-			return nil, backend.DownstreamErrorf("basic auth is not supported for Zabbix v7.2 and later")
+	if auth != "" && version >= 70 && version > 70 && api.dsSettings.BasicAuthEnabled {
+		return nil, backend.DownstreamErrorf("basic auth is not supported for Zabbix v7.2 and later")
+	}
+
+	// Build a fresh *http.Request for every attempt: the request body reader
+	// is consumed after it's written to the wire, so a retry needs its own copy.
+	newReq := func() (*http.Request, error) {
+		req, err := http.NewRequest(http.MethodPost, api.url.String(), bytes.NewReader(reqBodyJSON))
+		if err != nil {
+			return nil, err
 		}
-		if !api.dsSettings.BasicAuthEnabled {
+		if auth != "" && version >= 70 && !api.dsSettings.BasicAuthEnabled {
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", auth))
 		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("User-Agent", "Grafana/grafana-zabbix")
+		return req, nil
 	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", "Grafana/grafana-zabbix")
 
-	response, err := makeHTTPRequest(ctx, api.httpClient, req)
+	response, err := makeHTTPRequest(ctx, api.httpClient, newReq)
 	if err != nil {
 		return nil, err
 	}
@@ -214,15 +218,50 @@ func handleAPIResult(response []byte) (*simplejson.Json, error) {
 	return jsonResult, nil
 }
 
-func makeHTTPRequest(ctx context.Context, httpClient *http.Client, req *http.Request) ([]byte, error) {
-	// Set to true to prevents re-use of TCP connections (this may cause random EOF error in some request)
-	req.Close = true
-
-	res, err := ctxhttp.Do(ctx, httpClient, req)
+// makeHTTPRequest performs the HTTP round trip, reusing pooled connections
+// (no more forced req.Close=true - see doHTTPRequestOnce for why).
+func makeHTTPRequest(ctx context.Context, httpClient *http.Client, newReq func() (*http.Request, error)) ([]byte, error) {
+	body, err := doHTTPRequestOnce(ctx, httpClient, newReq)
+	if err != nil && isRetryableConnError(err) {
+		// The pooled connection was closed by the server/proxy in the small
+		// window between Go picking it from the idle pool and writing the
+		// request to it (classic keep-alive race, e.g. grafana-zabbix#1295).
+		// Nothing reached the server in that case, so retrying once with a
+		// brand-new connection is always safe, even for non-idempotent
+		// calls like user.login.
+		log.DefaultLogger.Debug("Retrying Zabbix API request after transient connection error", "error", err)
+		body, err = doHTTPRequestOnce(ctx, httpClient, newReq)
+	}
 	if err != nil {
 		if backend.IsDownstreamHTTPError(err) {
 			return nil, backend.DownstreamError(err)
 		}
+		return nil, err
+	}
+	return body, nil
+}
+
+// isRetryableConnError reports whether err is a network-level failure that
+// can only happen before the server ever saw the request (a stale pooled
+// connection being closed right as it's reused), making a retry safe.
+func isRetryableConnError(err error) bool {
+	return errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, syscall.ECONNRESET)
+}
+
+// doHTTPRequestOnce performs a single HTTP attempt. Connection-level errors
+// (nothing received yet) are returned unwrapped so the caller can decide
+// whether a retry is safe; HTTP-status-level errors are classified here since
+// they're never retry candidates.
+func doHTTPRequestOnce(ctx context.Context, httpClient *http.Client, newReq func() (*http.Request, error)) ([]byte, error) {
+	req, err := newReq()
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := ctxhttp.Do(ctx, httpClient, req)
+	if err != nil {
 		return nil, err
 	}
 	defer func() {
@@ -232,12 +271,12 @@ func makeHTTPRequest(ctx context.Context, httpClient *http.Client, req *http.Req
 	}()
 
 	if res.StatusCode != http.StatusOK {
-		err = fmt.Errorf("request failed, status: %v", res.Status)
+		statusErr := fmt.Errorf("request failed, status: %v", res.Status)
 		if backend.ErrorSourceFromHTTPStatus(res.StatusCode) == backend.ErrorSourceDownstream {
-			return nil, backend.DownstreamError(err)
+			return nil, backend.DownstreamError(statusErr)
 		}
 
-		return nil, err
+		return nil, statusErr
 	}
 
 	body, err := io.ReadAll(res.Body)

--- a/pkg/zabbixapi/zabbix_api.go
+++ b/pkg/zabbixapi/zabbix_api.go
@@ -218,6 +218,33 @@ func handleAPIResult(response []byte) (*simplejson.Json, error) {
 	return jsonResult, nil
 }
 
+// StatusError carries the actual upstream HTTP status code alongside the
+// error, so callers outside this package (e.g. the resource handler backing
+// the query-editor autocomplete) can report the real status instead of a
+// generic 500 - which is what the frontend's retry-on-502/503/504 logic
+// actually keys off of.
+type StatusError struct {
+	StatusCode int
+	err        error
+}
+
+func (e *StatusError) Error() string {
+	if e.err != nil {
+		return e.err.Error()
+	}
+	return fmt.Sprintf("request failed, status: %d", e.StatusCode)
+}
+func (e *StatusError) Unwrap() error { return e.err }
+
+// preResponseError marks a failure that happened before any response was
+// received from the server - i.e. the request is guaranteed to never have
+// reached it. Only these are safe to retry, even for non-idempotent calls
+// like user.login or script.execute.
+type preResponseError struct{ err error }
+
+func (e *preResponseError) Error() string { return e.err.Error() }
+func (e *preResponseError) Unwrap() error { return e.err }
+
 // makeHTTPRequest performs the HTTP round trip, reusing pooled connections
 // (no more forced req.Close=true - see doHTTPRequestOnce for why).
 func makeHTTPRequest(ctx context.Context, httpClient *http.Client, newReq func() (*http.Request, error)) ([]byte, error) {
@@ -243,17 +270,26 @@ func makeHTTPRequest(ctx context.Context, httpClient *http.Client, newReq func()
 
 // isRetryableConnError reports whether err is a network-level failure that
 // can only happen before the server ever saw the request (a stale pooled
-// connection being closed right as it's reused), making a retry safe.
+// connection being closed right as it's reused), making a retry safe. Errors
+// that happen while reading an already-received response (e.g. a truncated
+// body after a 200) are deliberately excluded even though they can present
+// the same io.EOF-shaped error - by then the server has already processed
+// the call, so retrying could re-run a non-idempotent action.
 func isRetryableConnError(err error) bool {
+	var preErr *preResponseError
+	if !errors.As(err, &preErr) {
+		return false
+	}
 	return errors.Is(err, io.EOF) ||
 		errors.Is(err, io.ErrUnexpectedEOF) ||
 		errors.Is(err, syscall.ECONNRESET)
 }
 
 // doHTTPRequestOnce performs a single HTTP attempt. Connection-level errors
-// (nothing received yet) are returned unwrapped so the caller can decide
-// whether a retry is safe; HTTP-status-level errors are classified here since
-// they're never retry candidates.
+// (nothing received yet) are wrapped in preResponseError so the caller can
+// decide whether a retry is safe; HTTP-status-level errors are classified
+// here (and carry the real status via StatusError) since they're never retry
+// candidates - the server has already responded by then.
 func doHTTPRequestOnce(ctx context.Context, httpClient *http.Client, newReq func() (*http.Request, error)) ([]byte, error) {
 	req, err := newReq()
 	if err != nil {
@@ -262,7 +298,7 @@ func doHTTPRequestOnce(ctx context.Context, httpClient *http.Client, newReq func
 
 	res, err := ctxhttp.Do(ctx, httpClient, req)
 	if err != nil {
-		return nil, err
+		return nil, &preResponseError{err: err}
 	}
 	defer func() {
 		if err := res.Body.Close(); err != nil {
@@ -272,13 +308,18 @@ func doHTTPRequestOnce(ctx context.Context, httpClient *http.Client, newReq func
 
 	if res.StatusCode != http.StatusOK {
 		statusErr := fmt.Errorf("request failed, status: %v", res.Status)
+		var wrapped error = statusErr
 		if backend.ErrorSourceFromHTTPStatus(res.StatusCode) == backend.ErrorSourceDownstream {
-			return nil, backend.DownstreamError(statusErr)
+			wrapped = backend.DownstreamError(statusErr)
 		}
 
-		return nil, statusErr
+		return nil, &StatusError{StatusCode: res.StatusCode, err: wrapped}
 	}
 
+	// The server already sent a 200 and we're mid-body here - a read failure
+	// (even an io.EOF-shaped one) is intentionally left unwrapped so
+	// isRetryableConnError never matches it: the call has already been
+	// processed by Zabbix, so it must not be retried.
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err

--- a/pkg/zabbixapi/zabbix_api.go
+++ b/pkg/zabbixapi/zabbix_api.go
@@ -308,12 +308,11 @@ func doHTTPRequestOnce(ctx context.Context, httpClient *http.Client, newReq func
 
 	if res.StatusCode != http.StatusOK {
 		statusErr := fmt.Errorf("request failed, status: %v", res.Status)
-		var wrapped error = statusErr
 		if backend.ErrorSourceFromHTTPStatus(res.StatusCode) == backend.ErrorSourceDownstream {
-			wrapped = backend.DownstreamError(statusErr)
+			return nil, &StatusError{StatusCode: res.StatusCode, err: backend.DownstreamError(statusErr)}
 		}
 
-		return nil, &StatusError{StatusCode: res.StatusCode, err: wrapped}
+		return nil, &StatusError{StatusCode: res.StatusCode, err: statusErr}
 	}
 
 	// The server already sent a 200 and we're mid-body here - a read failure

--- a/pkg/zabbixapi/zabbix_api_test.go
+++ b/pkg/zabbixapi/zabbix_api_test.go
@@ -3,6 +3,7 @@ package zabbixapi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -13,6 +14,51 @@ import (
 )
 
 var version = 65
+
+// TestRetryOnTransientConnectionError verifies the fix for the connection
+// storm: a single pre-response network failure (the classic stale
+// pooled-connection race, grafana-zabbix#1295) is retried once with a fresh
+// connection and the call still succeeds, instead of forcing every request
+// to open a brand-new connection (the old req.Close=true workaround).
+func TestRetryOnTransientConnectionError(t *testing.T) {
+	httpClient, attempts := NewFlakyTestClient(1, io.EOF, `{"result":"sampleResult"}`, 200)
+	zabbixApi, err := New(backend.DataSourceInstanceSettings{URL: "http://zabbix.org/zabbix"}, httpClient)
+	assert.NoError(t, err)
+
+	resp, err := zabbixApi.RequestUnauthenticated(context.Background(), "test.get", map[string]interface{}{}, version)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "sampleResult", resp.MustString())
+	assert.Equal(t, 2, *attempts, "expected exactly one retry after the transient EOF")
+}
+
+// TestRetryOnTransientConnectionErrorGivesUp verifies the retry is bounded:
+// a second consecutive connection failure is not retried again and
+// surfaces as an error, rather than looping forever.
+func TestRetryOnTransientConnectionErrorGivesUp(t *testing.T) {
+	httpClient, attempts := NewFlakyTestClient(2, io.EOF, `{"result":"sampleResult"}`, 200)
+	zabbixApi, err := New(backend.DataSourceInstanceSettings{URL: "http://zabbix.org/zabbix"}, httpClient)
+	assert.NoError(t, err)
+
+	_, err = zabbixApi.RequestUnauthenticated(context.Background(), "test.get", map[string]interface{}{}, version)
+
+	assert.Error(t, err)
+	assert.Equal(t, 2, *attempts, "should not retry more than once")
+}
+
+// TestNonRetryableErrorIsNotRetried verifies only the specific pre-response
+// network errors are retried - an arbitrary transport error surfaces
+// immediately, on the first attempt.
+func TestNonRetryableErrorIsNotRetried(t *testing.T) {
+	httpClient, attempts := NewFlakyTestClient(1, errors.New("boom"), `{"result":"sampleResult"}`, 200)
+	zabbixApi, err := New(backend.DataSourceInstanceSettings{URL: "http://zabbix.org/zabbix"}, httpClient)
+	assert.NoError(t, err)
+
+	_, err = zabbixApi.RequestUnauthenticated(context.Background(), "test.get", map[string]interface{}{}, version)
+
+	assert.Error(t, err)
+	assert.Equal(t, 1, *attempts, "non-retryable errors must not be retried")
+}
 
 func TestZabbixAPIUnauthenticatedQuery(t *testing.T) {
 	zabbixApi, _ := MockZabbixAPI(`{"result":"sampleResult"}`, 200)

--- a/pkg/zabbixapi/zabbix_api_test.go
+++ b/pkg/zabbixapi/zabbix_api_test.go
@@ -60,6 +60,38 @@ func TestNonRetryableErrorIsNotRetried(t *testing.T) {
 	assert.Equal(t, 1, *attempts, "non-retryable errors must not be retried")
 }
 
+// TestBodyReadFailureAfterOKIsNotRetried covers the case flagged in review:
+// a body-read error can look identical (io.ErrUnexpectedEOF) to the
+// pre-response stale-connection race, but by the time we're reading the
+// body the server has already sent a 200 and processed the call - retrying
+// here could re-run a non-idempotent action like user.login.
+func TestBodyReadFailureAfterOKIsNotRetried(t *testing.T) {
+	httpClient, attempts := NewTruncatedBodyTestClient(200, io.ErrUnexpectedEOF)
+	zabbixApi, err := New(backend.DataSourceInstanceSettings{URL: "http://zabbix.org/zabbix"}, httpClient)
+	assert.NoError(t, err)
+
+	_, err = zabbixApi.RequestUnauthenticated(context.Background(), "user.login", map[string]interface{}{}, version)
+
+	assert.Error(t, err)
+	assert.Equal(t, 1, *attempts, "a body-read failure after a 200 must never be retried")
+}
+
+// TestNon200ResponseCarriesUpstreamStatusCode verifies the error returned
+// for a non-200 response can be unwrapped to the real HTTP status code, so
+// callers like the resource handler can report it instead of a generic 500.
+func TestNon200ResponseCarriesUpstreamStatusCode(t *testing.T) {
+	zabbixApi, err := MockZabbixAPI(`{"error":{"message":"service unavailable"}}`, 503)
+	assert.NoError(t, err)
+
+	_, err = zabbixApi.RequestUnauthenticated(context.Background(), "test.get", map[string]interface{}{}, version)
+
+	assert.Error(t, err)
+	var statusErr *StatusError
+	if assert.True(t, errors.As(err, &statusErr), "expected error chain to contain *StatusError") {
+		assert.Equal(t, 503, statusErr.StatusCode)
+	}
+}
+
 func TestZabbixAPIUnauthenticatedQuery(t *testing.T) {
 	zabbixApi, _ := MockZabbixAPI(`{"result":"sampleResult"}`, 200)
 	resp, err := zabbixApi.RequestUnauthenticated(context.Background(), "test.get", map[string]interface{}{}, version)

--- a/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.test.ts
+++ b/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.test.ts
@@ -1,6 +1,11 @@
 import { ZabbixAPIConnector } from './zabbixAPIConnector';
 import { HostTagOperatorValue } from '../../../components/QueryEditor/types';
 import { ZabbixTagEvalType } from 'datasource/types/query';
+import { getBackendSrv } from '@grafana/runtime';
+
+jest.mock('@grafana/runtime', () => ({
+  getBackendSrv: jest.fn(),
+}));
 
 describe('Zabbix API connector', () => {
   const datasourceUID = 'test-datasource-uid';
@@ -496,6 +501,61 @@ describe('Zabbix API connector', () => {
         period_to: 7200,
         periods: 2,
       });
+    });
+  });
+
+  describe('backendAPIRequest retry on transient errors', () => {
+    afterEach(() => {
+      jest.useRealTimers();
+      jest.clearAllMocks();
+    });
+
+    it('retries a transient 503 and succeeds once the backend recovers', async () => {
+      jest.useFakeTimers();
+      const fetchMock = jest
+        .fn()
+        .mockReturnValueOnce({ toPromise: () => Promise.reject({ status: 503 }) })
+        .mockReturnValueOnce({ toPromise: () => Promise.resolve({ data: { result: 'ok' } }) });
+      (getBackendSrv as jest.Mock).mockReturnValue({ fetch: fetchMock });
+
+      const zabbixAPIConnector = new ZabbixAPIConnector('admin', true, datasourceUID);
+      const resultPromise = zabbixAPIConnector.backendAPIRequest('host.get', {});
+
+      await jest.advanceTimersByTimeAsync(1000);
+      const result = await resultPromise;
+
+      expect(result).toBe('ok');
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('gives up after exhausting retries on a persistent 503', async () => {
+      jest.useFakeTimers();
+      const fetchMock = jest.fn().mockReturnValue({ toPromise: () => Promise.reject({ status: 503 }) });
+      (getBackendSrv as jest.Mock).mockReturnValue({ fetch: fetchMock });
+
+      const zabbixAPIConnector = new ZabbixAPIConnector('admin', true, datasourceUID);
+      const resultPromise = zabbixAPIConnector.backendAPIRequest('host.get', {});
+      const assertion = expect(resultPromise).rejects.toThrow(/temporarily unavailable/i);
+
+      await jest.advanceTimersByTimeAsync(5000);
+      await assertion;
+
+      expect(fetchMock).toHaveBeenCalledTimes(3); // initial attempt + 2 retries
+    });
+
+    it('does not retry a non-transient error, e.g. a 400 validation/guardrail error', async () => {
+      const fetchMock = jest.fn().mockReturnValue({
+        toPromise: () => Promise.reject({ status: 400, data: { message: 'bad request' } }),
+      });
+      (getBackendSrv as jest.Mock).mockReturnValue({ fetch: fetchMock });
+
+      const zabbixAPIConnector = new ZabbixAPIConnector('admin', true, datasourceUID);
+
+      await expect(zabbixAPIConnector.backendAPIRequest('host.get', {})).rejects.toEqual({
+        status: 400,
+        data: { message: 'bad request' },
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
+++ b/src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts
@@ -12,6 +12,18 @@ import { zabbixMethodName } from 'datasource/zabbix/types';
 
 const DEFAULT_ZABBIX_VERSION = '3.0.0';
 
+// Transient upstream errors: the Zabbix web frontend (nginx/apache + php-fpm)
+// is momentarily overloaded/unreachable. Worth a couple of quick retries.
+// Anything else (4xx guardrail/validation errors, auth errors, etc.) should
+// surface immediately.
+const RETRYABLE_HTTP_STATUSES = [502, 503, 504];
+const MAX_RETRY_ATTEMPTS = 2;
+const RETRY_BASE_DELAY_MS = 300;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 /**
  * Zabbix API Wrapper.
  * Creates Zabbix API instance with given parameters (url, credentials and other).
@@ -74,8 +86,43 @@ export class ZabbixAPIConnector {
       requestOptions.headers.Authorization = this.requestOptions.basicAuth;
     }
 
-    const response = await getBackendSrv().fetch<any>(requestOptions).toPromise();
+    const response = await this.fetchWithRetry(requestOptions, method);
     return response?.data?.result;
+  }
+
+  /**
+   * Retries the resource-endpoint call a couple of times on a transient
+   * 502/503/504 from the Zabbix web frontend before giving up. This is the
+   * shared entry point for both the query-editor autocomplete calls
+   * (groups/hosts/items/apps) and all frontend-mode queries (triggers,
+   * problems, text metrics, user macros, IT services), so it's the one
+   * place worth softening against a momentarily overloaded Zabbix.
+   */
+  private async fetchWithRetry(requestOptions: BackendSrvRequest, method: zabbixMethodName, attempt = 0): Promise<any> {
+    try {
+      return await getBackendSrv().fetch<any>(requestOptions).toPromise();
+    } catch (error: any) {
+      const status = error?.status;
+      const isTransient = RETRYABLE_HTTP_STATUSES.includes(status);
+
+      if (isTransient && attempt < MAX_RETRY_ATTEMPTS) {
+        const backoffMs = RETRY_BASE_DELAY_MS * Math.pow(3, attempt);
+        console.warn(
+          `Zabbix API request "${method}" failed with ${status}, retrying in ${backoffMs}ms (attempt ${attempt + 1}/${MAX_RETRY_ATTEMPTS})`
+        );
+        await delay(backoffMs);
+        return this.fetchWithRetry(requestOptions, method, attempt + 1);
+      }
+
+      if (isTransient) {
+        throw new Error(
+          `Zabbix API is temporarily unavailable (HTTP ${status}) after ${MAX_RETRY_ATTEMPTS} retries. ` +
+            `The Zabbix server/frontend may be overloaded - check its logs and load.`
+        );
+      }
+
+      throw error;
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #2495

## Problem

Every backend API call implicitly re-fetched `apiinfo.version` on every
`Zabbix.Request()` instead of reusing the existing `ZabbixCache`, doubling
the number of HTTP requests per logical query. Each of those requests then
forced `req.Close = true`, disabling connection reuse entirely - a 2021
workaround (`a69c866b`, #1295) for a narrow stale-connection race, applied
far too broadly and left unchanged since.

Together: a dashboard with N panels/queries opened ~2N fresh TCP connections
to the Zabbix web frontend per load/refresh instead of ~N requests over a
couple of pooled connections. On modest self-hosted Zabbix installs this
exhausts php-fpm/connection limits under everyday use and surfaces as
widespread 502/503 in Grafana.

## Fix

- `pkg/zabbix/methods.go`: `GetFullVersion` now caches the result via the
  existing `ZabbixCache` (the same mechanism already used for
  `host.get`/`item.get`/etc.) instead of hitting the API on every call.
- `pkg/zabbixapi/zabbix_api.go`: removed `req.Close = true`. In its place,
  `makeHTTPRequest` retries once when the specific pre-response network
  error from #1295 (`io.EOF` / `io.ErrUnexpectedEOF` / `ECONNRESET`) occurs -
  safe even for non-idempotent calls, since by definition the server never
  saw the request in that case.
- `pkg/datasource/resource_handler.go`: `ZabbixAPIHandler` (backs the query
  editor's group/host/item/app autocomplete) is now bounded by the
  configured query timeout, matching the pattern already used in
  `QueryData`, so a slow/overloaded Zabbix can't hang it indefinitely.
  Also fixed `writeError` always responding with 500 regardless of the
  intended status code, and a nil-pointer panic when the request body is
  empty.
- `src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.ts`: the
  frontend now retries a transient 502/503/504 from the resource endpoint
  (with backoff) before surfacing an error - this is the shared path for
  metric-picker autocomplete and all frontend-mode queries (triggers,
  problems, text metrics, user macros, IT services).

The main metrics query pipeline (`DataSourceWithBackend.query()`) is
intentionally untouched - the root cause is fixed server-side, and
overriding that pipeline for retries felt like unnecessary risk for this PR.

## Testing

- `go test ./pkg/...` - full suite green, plus new tests:
  `TestVersionIsCachedAcrossRequests`, `TestRetryOnTransientConnectionError`,
  `TestRetryOnTransientConnectionErrorGivesUp`,
  `TestNonRetryableErrorIsNotRetried`.
- `yarn jest src/datasource/zabbix/connectors/zabbix_api/zabbixAPIConnector.test.ts`
  - full suite green, plus 3 new tests covering the retry/backoff/give-up
  behavior.
- `yarn typecheck` / `yarn eslint` on the changed files - clean (pre-existing
  `.toPromise()`/`withCredentials` deprecation warnings only, unrelated to
  this change).
- Load-tested against a real Zabbix 7.0 backend (zabbix-web-nginx-pgsql,
  6-worker static php-fpm pool) by replaying the plugin's exact old vs new
  request pattern directly against `api_jsonrpc.php`: ~2x fewer requests and
  ~2x faster at moderate concurrency (40 workers), and the old pattern
  degrades to ~98% failures at higher concurrency (~120+) against a backend
  that stays fully healthy under the fixed pattern. Happy to share the
  load-test script if useful.
