### PR TITLE
docs(readme): replace 404 install link with marketplace install tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Install by using `grafana-cli`
 grafana-cli plugins install alexanderzobnin-zabbix-app
 ```
 
-Or see more installation options in [docs](https://grafana.com/docs/plugins/alexanderzobnin-zabbix-app/latest/installation/).
+Or see more installation options in [docs](https://grafana.com/grafana/plugins/alexanderzobnin-zabbix-app/?tab=installation).
 
 ## Getting started
 
@@ -37,7 +37,7 @@ First, [configure](https://grafana.com/docs/plugins/alexanderzobnin-zabbix-app/l
 ## Documentation
 
 - [About](https://grafana.com/docs/plugins/alexanderzobnin-zabbix-app/latest/)
-- [Installation](https://grafana.com/docs/plugins/alexanderzobnin-zabbix-app/latest/installation)
+- [Installation](https://grafana.com/grafana/plugins/alexanderzobnin-zabbix-app/?tab=installation)
 - [Getting Started](https://grafana.com/docs/plugins/alexanderzobnin-zabbix-app/latest/guides)
 - [Templating](https://grafana.com/docs/plugins/alexanderzobnin-zabbix-app/latest/guides/templating)
 - [Alerting](https://grafana.com/docs/plugins/alexanderzobnin-zabbix-app/latest/reference/alerting/)


### PR DESCRIPTION
Fixes #2394. Supersedes #2397.

Adopts the fix from #2397 by @MukundaKatta, carried over unchanged via cherry-pick with original commit authorship preserved — all credit to them. Opening a fresh PR only because the original branch has been inactive and we'd like to land the fix.

Both `README.md` references to `grafana.com/docs/plugins/alexanderzobnin-zabbix-app/latest/installation` return 404 (verified today); the replacement marketplace installation-tab link resolves correctly (also verified today). The cherry-pick applied cleanly onto current `main`.

Thanks again @MukundaKatta for the contribution!